### PR TITLE
Using class-based PHPUnit namespace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,11 +15,11 @@ php-docker-template: &php-docker-template
   steps:
     - checkout
     - run:
-        name: validate composer.json
-        command: composer validate
+        name: update and validate composer.json
+        command: composer update && composer validate
     - run:
         name: install current dependencies
-        command: composer update --no-progress
+        command: composer install --no-progress
     - run:
         name: run tests with current dependency versions
         command: vendor/bin/phpunit --log-junit ~/phpunit/junit.xml --coverage-text tests
@@ -70,8 +70,8 @@ jobs:
             sudo php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer
       - checkout
       - run:
-          name: validate composer.json
-          command: composer validate
+          name: update and validate composer.json
+          command: composer update && composer validate
       - run:
           name: install current dependencies
           command: composer update --no-progress

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,6 @@ php-docker-template: &php-docker-template
         name: update and validate composer.json
         command: composer update && composer validate
     - run:
-        name: install current dependencies
-        command: composer install --no-progress
-    - run:
         name: run tests with current dependency versions
         command: vendor/bin/phpunit --log-junit ~/phpunit/junit.xml --coverage-text tests
     - store_test_results:
@@ -72,9 +69,6 @@ jobs:
       - run:
           name: update and validate composer.json
           command: composer update && composer validate
-      - run:
-          name: install current dependencies
-          command: composer update --no-progress
       - run:
           name: run php-cs-fixer
           command: vendor/bin/php-cs-fixer fix --diff --dry-run --verbose

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ php-docker-template: &php-docker-template
         command: composer validate
     - run:
         name: install current dependencies
-        command: composer install --no-progress
+        command: composer update --no-progress
     - run:
         name: run tests with current dependency versions
         command: vendor/bin/phpunit --log-junit ~/phpunit/junit.xml --coverage-text tests
@@ -74,7 +74,7 @@ jobs:
           command: composer validate
       - run:
           name: install current dependencies
-          command: composer install --no-progress
+          command: composer update --no-progress
       - run:
           name: run php-cs-fixer
           command: vendor/bin/php-cs-fixer fix --diff --dry-run --verbose

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "guzzlehttp/guzzle": "^6.2.1",
         "kevinrob/guzzle-cache-middleware": "^1.4.1",
         "phpdocumentor/phpdocumentor": "^2.0",
-        "phpunit/phpunit": ">=4.8.26 <5.4",
+        "phpunit/phpunit": ">=4.8.36",
         "predis/predis": "^1.0",
         "zendframework/zend-serializer": "^2.7"
     },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "guzzlehttp/guzzle": "^6.2.1",
         "kevinrob/guzzle-cache-middleware": "^1.4.1",
         "phpdocumentor/phpdocumentor": "^2.0",
-        "phpunit/phpunit": ">=4.8.36",
+        "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5",
         "predis/predis": "^1.0",
         "zendframework/zend-serializer": "^2.7"
     },

--- a/tests/EvaluationReasonTest.php
+++ b/tests/EvaluationReasonTest.php
@@ -2,8 +2,9 @@
 namespace LaunchDarkly\Tests;
 
 use LaunchDarkly\EvaluationReason;
+use PHPUnit\Framework\TestCase;
 
-class EvaluationReasonTest extends \PHPUnit_Framework_TestCase
+class EvaluationReasonTest extends TestCase
 {
     public function testOffReasonSerialization()
     {

--- a/tests/EventSerializerTest.php
+++ b/tests/EventSerializerTest.php
@@ -3,8 +3,9 @@ namespace LaunchDarkly\Tests;
 
 use LaunchDarkly\EventSerializer;
 use LaunchDarkly\LDUserBuilder;
+use PHPUnit\Framework\TestCase;
 
-class EventSerializerTest extends \PHPUnit_Framework_TestCase
+class EventSerializerTest extends TestCase
 {
     private function getUser()
     {
@@ -13,7 +14,7 @@ class EventSerializerTest extends \PHPUnit_Framework_TestCase
             ->custom(array('bizzle' => 'def', 'dizzle' => 'ghi'))
             ->build();
     }
-    
+
     private function getUserSpecifyingOwnPrivateAttr()
     {
         return (new LDUserBuilder('abc'))
@@ -22,7 +23,7 @@ class EventSerializerTest extends \PHPUnit_Framework_TestCase
             ->privateCustomAttribute('dizzle', 'ghi')
             ->build();
     }
-    
+
     private function getFullUserResult()
     {
         return array(
@@ -31,7 +32,7 @@ class EventSerializerTest extends \PHPUnit_Framework_TestCase
             'custom' => array('bizzle' => 'def', 'dizzle' => 'ghi')
         );
     }
-    
+
     private function getUserResultWithAllAttrsHidden()
     {
         return array(
@@ -39,7 +40,7 @@ class EventSerializerTest extends \PHPUnit_Framework_TestCase
             'privateAttrs' => array('bizzle', 'dizzle', 'firstName')
         );
     }
-    
+
     private function getUserResultWithSomeAttrsHidden()
     {
         return array(
@@ -48,7 +49,7 @@ class EventSerializerTest extends \PHPUnit_Framework_TestCase
             'privateAttrs' => array('bizzle', 'firstName')
         );
     }
-    
+
     private function getUserResultWithOwnSpecifiedAttrHidden()
     {
         return array(
@@ -58,7 +59,7 @@ class EventSerializerTest extends \PHPUnit_Framework_TestCase
             'privateAttrs' => array('dizzle')
         );
     }
-    
+
     private function makeEvent($user)
     {
         return array(
@@ -68,14 +69,14 @@ class EventSerializerTest extends \PHPUnit_Framework_TestCase
             'user' => $user
         );
     }
-    
+
     private function getJsonForUserBySerializingEvent($user)
     {
         $es = new EventSerializer(array());
         $event = $this->makeEvent($user);
         return json_decode($es->serializeEvents(array($event)), true)[0]['user'];
     }
-    
+
     public function testAllUserAttrsSerialized()
     {
         $es = new EventSerializer(array());
@@ -93,7 +94,7 @@ class EventSerializerTest extends \PHPUnit_Framework_TestCase
         $expected = $this->makeEvent($this->getUserResultWithAllAttrsHidden());
         $this->assertEquals(array($expected), json_decode($json, true));
     }
-    
+
     public function testSomeUserAttrsPrivate()
     {
         $es = new EventSerializer(array('private_attribute_names' => array('firstName', 'bizzle')));
@@ -102,7 +103,7 @@ class EventSerializerTest extends \PHPUnit_Framework_TestCase
         $expected = $this->makeEvent($this->getUserResultWithSomeAttrsHidden());
         $this->assertEquals(array($expected), json_decode($json, true));
     }
-    
+
     public function testPerUserPrivateAttr()
     {
         $es = new EventSerializer(array());
@@ -120,7 +121,7 @@ class EventSerializerTest extends \PHPUnit_Framework_TestCase
         $expected = $this->makeEvent($this->getUserResultWithAllAttrsHidden());
         $this->assertEquals(array($expected), json_decode($json, true));
     }
-    
+
     public function testUserKey()
     {
         $builder = new LDUserBuilder("foo@bar.com");
@@ -128,7 +129,7 @@ class EventSerializerTest extends \PHPUnit_Framework_TestCase
         $json = $this->getJsonForUserBySerializingEvent($user);
         $this->assertEquals("foo@bar.com", $json['key']);
     }
-    
+
     public function testEmptyCustom()
     {
         $builder = new LDUserBuilder("foo@bar.com");
@@ -152,7 +153,7 @@ class EventSerializerTest extends \PHPUnit_Framework_TestCase
         $json = $this->getJsonForUserBySerializingEvent($user);
         $this->assertEquals("secondary", $json['secondary']);
     }
-    
+
     public function testUserIP()
     {
         $builder = new LDUserBuilder("foo@bar.com");
@@ -160,7 +161,7 @@ class EventSerializerTest extends \PHPUnit_Framework_TestCase
         $json = $this->getJsonForUserBySerializingEvent($user);
         $this->assertEquals("127.0.0.1", $json['ip']);
     }
-    
+
     public function testUserCountry()
     {
         $builder = new LDUserBuilder("foo@bar.com");
@@ -168,7 +169,7 @@ class EventSerializerTest extends \PHPUnit_Framework_TestCase
         $json = $this->getJsonForUserBySerializingEvent($user);
         $this->assertEquals("US", $json['country']);
     }
-    
+
     public function testUserEmail()
     {
         $builder = new LDUserBuilder("foo@bar.com");
@@ -176,7 +177,7 @@ class EventSerializerTest extends \PHPUnit_Framework_TestCase
         $json = $this->getJsonForUserBySerializingEvent($user);
         $this->assertEquals("foo+test@bar.com", $json['email']);
     }
-    
+
     public function testUserName()
     {
         $builder = new LDUserBuilder("foo@bar.com");
@@ -184,7 +185,7 @@ class EventSerializerTest extends \PHPUnit_Framework_TestCase
         $json = $this->getJsonForUserBySerializingEvent($user);
         $this->assertEquals("Foo Bar", $json['name']);
     }
-    
+
     public function testUserAvatar()
     {
         $builder = new LDUserBuilder("foo@bar.com");
@@ -192,7 +193,7 @@ class EventSerializerTest extends \PHPUnit_Framework_TestCase
         $json = $this->getJsonForUserBySerializingEvent($user);
         $this->assertEquals("http://www.gravatar.com/avatar/1", $json['avatar']);
     }
-    
+
     public function testUserFirstName()
     {
         $builder = new LDUserBuilder("foo@bar.com");
@@ -200,7 +201,7 @@ class EventSerializerTest extends \PHPUnit_Framework_TestCase
         $json = $this->getJsonForUserBySerializingEvent($user);
         $this->assertEquals("Foo", $json['firstName']);
     }
-    
+
     public function testUserLastName()
     {
         $builder = new LDUserBuilder("foo@bar.com");
@@ -208,7 +209,7 @@ class EventSerializerTest extends \PHPUnit_Framework_TestCase
         $json = $this->getJsonForUserBySerializingEvent($user);
         $this->assertEquals("Bar", $json['lastName']);
     }
-    
+
     public function testUserAnonymous()
     {
         $builder = new LDUserBuilder("foo@bar.com");

--- a/tests/FeatureFlagTest.php
+++ b/tests/FeatureFlagTest.php
@@ -7,8 +7,9 @@ use LaunchDarkly\FeatureFlag;
 use LaunchDarkly\LDUser;
 use LaunchDarkly\LDUserBuilder;
 use LaunchDarkly\Segment;
+use PHPUnit\Framework\TestCase;
 
-class FeatureFlagTest extends \PHPUnit_Framework_TestCase
+class FeatureFlagTest extends TestCase
 {
     private static $json1 = "{
   \"key\": \"integration.feature.0\",
@@ -146,7 +147,7 @@ class FeatureFlagTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(FeatureFlag::class, FeatureFlag::decode(\GuzzleHttp\json_decode(FeatureFlagTest::$json1, true)));
         $this->assertInstanceOf(FeatureFlag::class, FeatureFlag::decode(\GuzzleHttp\json_decode(FeatureFlagTest::$json2, true)));
     }
-    
+
     public function dataDecodeMulti()
     {
         return [
@@ -182,7 +183,7 @@ class FeatureFlagTest extends \PHPUnit_Framework_TestCase
             ],
         ];
     }
-    
+
     /**
      * @dataProvider dataDecodeMulti
      * @param array $feature
@@ -190,7 +191,7 @@ class FeatureFlagTest extends \PHPUnit_Framework_TestCase
     public function testDecodeMulti(array $feature)
     {
         $featureFlag = FeatureFlag::decode($feature);
-        
+
         self::assertInstanceOf(FeatureFlag::class, $featureFlag);
     }
 
@@ -701,7 +702,7 @@ class FeatureFlagTest extends \PHPUnit_Framework_TestCase
     public function testSegmentMatchClauseFallsThroughWithNoErrorsIfSegmentNotFound()
     {
         $requester = new MockFeatureRequesterForSegment();
-        
+
         $feature = $this->makeBooleanFeatureWithSegmentMatch('segkey');
 
         $ub = new LDUserBuilder('foo');

--- a/tests/FeatureFlagsStateTest.php
+++ b/tests/FeatureFlagsStateTest.php
@@ -6,8 +6,9 @@ use LaunchDarkly\EvaluationDetail;
 use LaunchDarkly\EvaluationReason;
 use LaunchDarkly\FeatureFlag;
 use LaunchDarkly\FeatureFlagsState;
+use PHPUnit\Framework\TestCase;
 
-class FeatureFlagsStateTest extends \PHPUnit_Framework_TestCase
+class FeatureFlagsStateTest extends TestCase
 {
     private static $flag1Json = array(
         'key' => 'key1',
@@ -51,7 +52,7 @@ class FeatureFlagsStateTest extends \PHPUnit_Framework_TestCase
     public function testUnknownFlagReturnsNullValue()
     {
         $state = new FeatureFlagsState(true);
-        
+
         $this->assertNull($state->getFlagValue('key1'));
     }
 

--- a/tests/LDClientTest.php
+++ b/tests/LDClientTest.php
@@ -9,8 +9,9 @@ use LaunchDarkly\LDClient;
 use LaunchDarkly\LDUser;
 use LaunchDarkly\LDUserBuilder;
 use Psr\Log\LoggerInterface;
+use PHPUnit\Framework\TestCase;
 
-class LDClientTest extends \PHPUnit_Framework_TestCase
+class LDClientTest extends TestCase
 {
     public function testDefaultCtor()
     {
@@ -305,7 +306,7 @@ class LDClientTest extends \PHPUnit_Framework_TestCase
         $builder = new LDUserBuilder(3);
         $user = $builder->build();
         $state = $client->allFlagsState($user);
-         
+
         $this->assertTrue($state->isValid());
         $this->assertEquals(array('feature' => 'off'), $state->toValuesMap());
         $expectedState = array(
@@ -351,7 +352,7 @@ class LDClientTest extends \PHPUnit_Framework_TestCase
         $builder = new LDUserBuilder(3);
         $user = $builder->build();
         $state = $client->allFlagsState($user, array('withReasons' => true));
-         
+
         $this->assertTrue($state->isValid());
         $this->assertEquals(array('feature' => 'off'), $state->toValuesMap());
         $expectedState = array(
@@ -396,7 +397,7 @@ class LDClientTest extends \PHPUnit_Framework_TestCase
         $builder = new LDUserBuilder(3);
         $user = $builder->build();
         $state = $client->allFlagsState($user, array('clientSideOnly' => true));
-         
+
         $this->assertTrue($state->isValid());
         $this->assertEquals(array('client-side-1' => 'value1', 'client-side-2' => 'value2'), $state->toValuesMap());
     }
@@ -413,29 +414,29 @@ class LDClientTest extends \PHPUnit_Framework_TestCase
         $user = new LDUser("Message");
         $this->assertEquals("aa747c502a898200f9e4fa21bac68136f886a0e27aec70ba06daf2e2a5cb5597", $client->secureModeHash($user));
     }
-    
+
     public function testLoggerInterfaceWarn()
     {
         // Use LoggerInterface impl, instead of concreate Logger from Monolog, to demonstrate the problem with `warn`.
         $logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
-        
+
         $logger->expects(self::atLeastOnce())->method('warning');
-        
+
         $client = new LDClient('secret', [
             'logger' => $logger,
         ]);
-    
+
         $user = new LDUser('');
-        
+
         $client->variation('MyFeature', $user);
     }
-    
+
     private function getPrivateField(&$object, $fieldName)
     {
         $reflection = new \ReflectionClass(get_class($object));
         $field = $reflection->getProperty($fieldName);
         $field->setAccessible(true);
-    
+
         return $field->getValue($object);
     }
 }

--- a/tests/LDClientTest.php
+++ b/tests/LDClientTest.php
@@ -402,9 +402,11 @@ class LDClientTest extends TestCase
         $this->assertEquals(array('client-side-1' => 'value1', 'client-side-2' => 'value2'), $state->toValuesMap());
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     */
     public function testOnlyValidFeatureRequester()
     {
-        $this->setExpectedException(InvalidArgumentException::class);
         new LDClient("BOGUS_SDK_KEY", ['feature_requester_class' => \stdClass::class]);
     }
 

--- a/tests/LDDFeatureRequesterTest.php
+++ b/tests/LDDFeatureRequesterTest.php
@@ -7,33 +7,34 @@ use LaunchDarkly\LDDFeatureRequester;
 use Predis\ClientInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use PHPUnit\Framework\TestCase;
 
-class LDDFeatureRequesterTest extends \PHPUnit_Framework_TestCase
+class LDDFeatureRequesterTest extends TestCase
 {
     /** @var ClientInterface|\PHPUnit_Framework_MockObject_MockObject */
     private $predisClient;
-    
+
     /** @var LoggerInterface */
     private $logger;
-    
+
     protected function setUp()
     {
         parent::setUp();
-        
+
         $this->logger = new NullLogger();
-        
+
         $this->predisClient = $this->getMockBuilder(ClientInterface::class)
             ->setMethods(['hget'])
             ->getMockForAbstractClass();
     }
-    
+
     public function testGetFeature()
     {
         $sut = new LDDFeatureRequester('example.com', 'MySdkKey', [
             'logger' => $this->logger,
             'predis_client' => $this->predisClient,
         ]);
-        
+
         $this->predisClient->method('hget')->with('launchdarkly:features', 'foo')
             ->willReturn(json_encode([
                 'key' => 'foo',
@@ -63,9 +64,9 @@ class LDDFeatureRequesterTest extends \PHPUnit_Framework_TestCase
                 ],
                 'deleted' => false,
             ]));
-        
+
         $featureFlag = $sut->getFeature('foo');
-        
+
         self::assertInstanceOf(FeatureFlag::class, $featureFlag);
         self::assertTrue($featureFlag->isOn());
     }

--- a/tests/LDUserTest.php
+++ b/tests/LDUserTest.php
@@ -3,8 +3,9 @@ namespace LaunchDarkly\Tests;
 
 use LaunchDarkly\LDUser;
 use LaunchDarkly\LDUserBuilder;
+use PHPUnit\Framework\TestCase;
 
-class LDUserTest extends \PHPUnit_Framework_TestCase
+class LDUserTest extends TestCase
 {
     public function testLDUserKey()
     {
@@ -23,9 +24,9 @@ class LDUserTest extends \PHPUnit_Framework_TestCase
     public function testEmptyCustom()
     {
         $builder = new LDUserBuilder("foo@bar.com");
-        
+
         $user = $builder->build();
-        
+
         $this->assertInstanceOf(LDUser::class, $user);
     }
 

--- a/tests/OperatorsTest.php
+++ b/tests/OperatorsTest.php
@@ -3,8 +3,9 @@
 namespace LaunchDarkly\Tests;
 
 use LaunchDarkly\Operators;
+use PHPUnit\Framework\TestCase;
 
-class OperatorsTest extends \PHPUnit_Framework_TestCase
+class OperatorsTest extends TestCase
 {
     public function testIn()
     {

--- a/tests/SegmentTest.php
+++ b/tests/SegmentTest.php
@@ -3,8 +3,9 @@ namespace LaunchDarkly\Tests;
 
 use LaunchDarkly\LDUserBuilder;
 use LaunchDarkly\Segment;
+use PHPUnit\Framework\TestCase;
 
-class SegmentTest extends \PHPUnit_Framework_TestCase
+class SegmentTest extends TestCase
 {
     public function testExplicitIncludeUser()
     {

--- a/tests/SemanticVersionTest.php
+++ b/tests/SemanticVersionTest.php
@@ -3,8 +3,9 @@
 namespace LaunchDarkly\Tests;
 
 use LaunchDarkly\SemanticVersion;
+use PHPUnit\Framework\TestCase;
 
-class SemanticVersionTest extends \PHPUnit_Framework_TestCase
+class SemanticVersionTest extends TestCase
 {
     public function testCanParseSimpleCompleteVersion()
     {


### PR DESCRIPTION
# Changed log
- Using the class-based PHPUnit namespace to be compatible with latest PHPUnit version.