### PR TITLE
Add phpredis FeatureRequester

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,12 @@ php-docker-template: &php-docker-template
         name: install dependencies
         command: composer install --no-progress
     - run:
+        name: setup phpredis
+        command: |
+          pecl config-set php_ini /usr/local/etc/php/php.ini
+          yes '' | sudo pecl install -f redis || true;
+          echo "extension=redis.so" | sudo tee -a /usr/local/etc/php/conf.d/redis.ini;
+    - run:
         name: run tests with highest compatible dependency versions
         command: vendor/bin/phpunit --log-junit ~/phpunit/junit.xml --coverage-text tests
     - store_test_results:

--- a/src/LaunchDarkly/Impl/Integrations/PHPRedisFeatureRequester.php
+++ b/src/LaunchDarkly/Impl/Integrations/PHPRedisFeatureRequester.php
@@ -1,0 +1,58 @@
+<?php
+namespace LaunchDarkly\Impl\Integrations;
+
+use Psr\Log\LoggerInterface;
+
+class PHPRedisFeatureRequester extends FeatureRequesterBase
+{
+    /** @var array */
+    private $_redisOptions;
+    /** @var Redis */
+    private $_redisInstance;
+    /** @var string */
+    private $_prefix;
+
+    public function __construct($baseUri, $sdkKey, $options)
+    {
+        parent::__construct($baseUri, $sdkKey, $options);
+
+        $this->_prefix = isset($options['redis_prefix']) ? $options['redis_prefix'] : 'launchdarkly';
+
+        if (isset($this->_options['phpredis_client']) && $this->_options['phpredis_client'] instanceof Redis) {
+            $this->_connection = $this->_options['phpredis_client'];
+        } else {
+            $this->_redisOptions = array(
+                "timeout" => isset($options['redis_timeout']) ? $options['redis_timeout'] : 5,
+                "host" => isset($options['redis_host']) ? $options['redis_host'] : 'localhost',
+                "port" => isset($options['redis_port']) ? $options['redis_port'] : 6379
+            );
+        }
+    }
+
+    protected function readItemString($namespace, $key)
+    {
+        $redis = $this->getConnection();
+        return $redis->hget("$this->_prefix:$namespace", $key);
+    }
+
+    protected function readItemStringList($namespace)
+    {
+        $redis = $this->getConnection();
+        $raw = $redis->hgetall("$this->_prefix:$namespace");
+        return $raw ? array_values($raw) : null;
+    }
+
+    /**
+     * @return ClientInterface
+     */
+    protected function getConnection()
+    {
+        if ($this->_redisInstance instanceof Redis) {
+            return $this->_redisInstance;
+        }
+
+        $redis = new Redis();
+        $redis->pconnect($this->_redisOptions["host"],$this->_redisOptions["post"]);
+        return $this->_redisInstance = $redis;
+    }
+}

--- a/src/LaunchDarkly/Impl/Integrations/PHPRedisFeatureRequester.php
+++ b/src/LaunchDarkly/Impl/Integrations/PHPRedisFeatureRequester.php
@@ -58,7 +58,7 @@ class PHPRedisFeatureRequester extends FeatureRequesterBase
             $this->_redisOptions["timeout"],
             'x'
         );
-        $redis->setOption(Redis::OPT_PREFIX, "$this->_prefix:");	// use custom prefix on all keys
+        $redis->setOption(\Redis::OPT_PREFIX, "$this->_prefix:");	// use custom prefix on all keys
         return $this->_redisInstance = $redis;
     }
 }

--- a/src/LaunchDarkly/Impl/Integrations/PHPRedisFeatureRequester.php
+++ b/src/LaunchDarkly/Impl/Integrations/PHPRedisFeatureRequester.php
@@ -52,7 +52,12 @@ class PHPRedisFeatureRequester extends FeatureRequesterBase
         }
 
         $redis = new Redis();
-        $redis->pconnect($this->_redisOptions["host"],$this->_redisOptions["post"]);
+        $redis->pconnect(
+            $this->_redisOptions["host"],
+            $this->_redisOptions["post"],
+            $this->_redisOptions["timeout"],
+            'x'
+        );
         return $this->_redisInstance = $redis;
     }
 }

--- a/src/LaunchDarkly/Impl/Integrations/PHPRedisFeatureRequester.php
+++ b/src/LaunchDarkly/Impl/Integrations/PHPRedisFeatureRequester.php
@@ -32,13 +32,13 @@ class PHPRedisFeatureRequester extends FeatureRequesterBase
     protected function readItemString($namespace, $key)
     {
         $redis = $this->getConnection();
-        return $redis->hget("$this->_prefix:$namespace", $key);
+        return $redis->hget($namespace, $key);
     }
 
     protected function readItemStringList($namespace)
     {
         $redis = $this->getConnection();
-        $raw = $redis->hgetall("$this->_prefix:$namespace");
+        $raw = $redis->hgetall($namespace);
         return $raw ? array_values($raw) : null;
     }
 
@@ -58,6 +58,7 @@ class PHPRedisFeatureRequester extends FeatureRequesterBase
             $this->_redisOptions["timeout"],
             'x'
         );
+        $redis->setOption(Redis::OPT_PREFIX, "$this->_prefix:");	// use custom prefix on all keys
         return $this->_redisInstance = $redis;
     }
 }

--- a/src/LaunchDarkly/Impl/Integrations/PHPRedisFeatureRequester.php
+++ b/src/LaunchDarkly/Impl/Integrations/PHPRedisFeatureRequester.php
@@ -54,7 +54,7 @@ class PHPRedisFeatureRequester extends FeatureRequesterBase
         $redis = new \Redis();
         $redis->pconnect(
             $this->_redisOptions["host"],
-            $this->_redisOptions["post"],
+            $this->_redisOptions["port"],
             $this->_redisOptions["timeout"],
             'x'
         );

--- a/src/LaunchDarkly/Impl/Integrations/PHPRedisFeatureRequester.php
+++ b/src/LaunchDarkly/Impl/Integrations/PHPRedisFeatureRequester.php
@@ -7,7 +7,7 @@ class PHPRedisFeatureRequester extends FeatureRequesterBase
 {
     /** @var array */
     private $_redisOptions;
-    /** @var Redis */
+    /** @var \Redis */
     private $_redisInstance;
     /** @var string */
     private $_prefix;
@@ -43,7 +43,7 @@ class PHPRedisFeatureRequester extends FeatureRequesterBase
     }
 
     /**
-     * @return ClientInterface
+     * @return \Redis
      */
     protected function getConnection()
     {
@@ -51,7 +51,7 @@ class PHPRedisFeatureRequester extends FeatureRequesterBase
             return $this->_redisInstance;
         }
 
-        $redis = new Redis();
+        $redis = new \Redis();
         $redis->pconnect(
             $this->_redisOptions["host"],
             $this->_redisOptions["post"],

--- a/src/LaunchDarkly/Integrations/PHPRedis.php
+++ b/src/LaunchDarkly/Integrations/PHPRedis.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace LaunchDarkly\Integrations;
+
+/**
+ * Integration with a Redis data store.
+ * @since ???
+ */
+class PHPRedis
+{
+    /**
+     * Configures an adapter for reading feature flag data from Redis using persistent connections.
+     *
+     * To use this method, you must have installed the `phpredis` extension. After calling this
+     * method, store its return value in the `feature_requester` property of your client configuration:
+     *
+     *     $fr = LaunchDarkly\Integrations\PHPRedis::featureRequester([ "redis_prefix" => "env1" ]);
+     *     $config = [ "feature_requester" => $fr ];
+     *     $client = new LDClient("sdk_key", $config);
+     *
+     * For more about using LaunchDarkly with databases, see the
+     * [SDK reference guide](https://docs.launchdarkly.com/v2.0/docs/using-a-persistent-feature-store).
+     *
+     * @param array $options  Configuration settings (can also be passed in the main client configuration):
+     *   - `redis_host`: hostname of the Redis server; defaults to `localhost`
+     *   - `redis_port`: port of the Redis server; defaults to 6379
+     *   - `redis_timeout`: connection timeout in seconds; defaults to 5
+     *   - `redis_prefix`: a string to be prepended to all database keys; corresponds to the prefix
+     * setting in ld-relay
+     *   - `phpredis_client`: an already-configured Predis client instance if you wish to reuse one
+     *   - `apc_expiration`: expiration time in seconds for local caching, if `APCu` is installed
+     * @return object  an object to be stored in the `feature_requester` configuration property
+     */
+    public static function featureRequester($options = array())
+    {
+        return function ($baseUri, $sdkKey, $baseOptions) use ($options) {
+            return new \LaunchDarkly\Impl\Integrations\PHPRedisFeatureRequester($baseUri, $sdkKey,
+                array_merge($baseOptions, $options));
+        };
+    }
+}

--- a/src/LaunchDarkly/Integrations/PHPRedis.php
+++ b/src/LaunchDarkly/Integrations/PHPRedis.php
@@ -33,6 +33,9 @@ class PHPRedis
      */
     public static function featureRequester($options = array())
     {
+        if (!extension_loaded('redis')) {
+            throw new \RuntimeException("phpredis extension is required to use Integrations::PHPRedis");
+        }
         return function ($baseUri, $sdkKey, $baseOptions) use ($options) {
             return new \LaunchDarkly\Impl\Integrations\PHPRedisFeatureRequester($baseUri, $sdkKey,
                 array_merge($baseOptions, $options));

--- a/tests/PHPRedisFeatureRequesterTest.php
+++ b/tests/PHPRedisFeatureRequesterTest.php
@@ -2,7 +2,7 @@
 
 namespace LaunchDarkly\Tests;
 
-use LaunchDarkly\Integrations\Redis;
+use LaunchDarkly\Integrations\PHPRedis;
 
 class PHPRedisFeatureRequesterTest extends FeatureRequesterTestBase
 {

--- a/tests/PHPRedisFeatureRequesterTest.php
+++ b/tests/PHPRedisFeatureRequesterTest.php
@@ -4,6 +4,9 @@ namespace LaunchDarkly\Tests;
 
 use LaunchDarkly\Integrations\PHPRedis;
 
+/**
+* @requires PHP >= 7.0
+*/
 class PHPRedisFeatureRequesterTest extends FeatureRequesterTestBase
 {
     const PREFIX = 'test';

--- a/tests/PHPRedisFeatureRequesterTest.php
+++ b/tests/PHPRedisFeatureRequesterTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace LaunchDarkly\Tests;
+
+use LaunchDarkly\Integrations\Redis;
+
+class PHPRedisFeatureRequesterTest extends FeatureRequesterTestBase
+{
+    const PREFIX = 'test';
+
+    /** @var \Redis */
+    private static $redisClient;
+    
+    public static function setUpBeforeClass()
+    {
+        if (!static::isSkipDatabaseTests()) {
+            $redis = new \Redis();
+            $redis->connect('127.0.0.1', 6379);
+            self::$redisClient = $redis;
+        }
+    }
+
+    protected function isDatabaseTest()
+    {
+        return true;
+    }
+    
+    protected function makeRequester()
+    {
+        $factory = PHPRedis::featureRequester();
+        return $factory('', '', array('redis_prefix' => self::PREFIX));
+    }
+
+    protected function putItem($namespace, $key, $version, $json)
+    {
+        self::$redisClient->hset(self::PREFIX . ":$namespace", $key, $json);
+    }
+
+    protected function deleteExistingData()
+    {
+        self::$redisClient->flushdb();
+    }
+}

--- a/tests/PHPRedisFeatureRequesterTest.php
+++ b/tests/PHPRedisFeatureRequesterTest.php
@@ -5,8 +5,8 @@ namespace LaunchDarkly\Tests;
 use LaunchDarkly\Integrations\PHPRedis;
 
 /**
-* @requires PHP >= 7.0
-*/
+ * @requires extension redis
+ */
 class PHPRedisFeatureRequesterTest extends FeatureRequesterTestBase
 {
     const PREFIX = 'test';


### PR DESCRIPTION
**Requirements**

- [X] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

This PR adds [PHPRedis](https://github.com/phpredis/phpredis) as a Feature Requester option. 
The goal behind this is to allow the library to use persistent connections, avoiding the overhead of reconnecting to the Redis server on each request.

