### PR TITLE
fix namespace on dummy implementation to match PSR-4

### DIFF
--- a/src/LaunchDarkly/Impl/NullEventProcessor.php
+++ b/src/LaunchDarkly/Impl/NullEventProcessor.php
@@ -1,5 +1,5 @@
 <?php
-namespace LaunchDarkly;
+namespace LaunchDarkly\Impl;
 
 class NullEventProcessor
 {


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

None

**Describe the solution you've provided**

I've corrected the namespace for NullEventProcessor to match its place in the folder structure.

**Describe alternatives you've considered**

None

**Additional context**

Composer 1.10 began emitting this notice about version 3.7.1. This issue also exists in master.

```
Deprecation Notice: Class LaunchDarkly\NullEventProcessor located in ./vendor/launchdarkly/server-sdk/src/LaunchDarkly/Impl/NullEventProcessor.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
```
