### PR TITLE
TTL : Allow different cache strategy (exemple: greedyCacheStrategy) 

### DIFF
--- a/src/LaunchDarkly/Impl/Integrations/GuzzleFeatureRequester.php
+++ b/src/LaunchDarkly/Impl/Integrations/GuzzleFeatureRequester.php
@@ -5,6 +5,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\HandlerStack;
 use Kevinrob\GuzzleCache\CacheMiddleware;
+use Kevinrob\GuzzleCache\Strategy\CacheStrategyInterface;
 use Kevinrob\GuzzleCache\Strategy\PublicCacheStrategy;
 use LaunchDarkly\FeatureFlag;
 use LaunchDarkly\FeatureRequester;
@@ -35,7 +36,10 @@ class GuzzleFeatureRequester implements FeatureRequester
         $this->_logger = $options['logger'];
         $stack = HandlerStack::create();
         if (class_exists('Kevinrob\GuzzleCache\CacheMiddleware')) {
-            $stack->push(new CacheMiddleware(new PublicCacheStrategy(isset($options['cache']) ? $options['cache'] : null)), 'cache');
+            $cacheOption = isset($options['cache']) ? $options['cache'] : null;
+            $cacheOption instanceof CacheStrategyInterface
+                ? $stack->push(new CacheMiddleware($cacheOption), 'cache')
+                : $stack->push(new CacheMiddleware(new PublicCacheStrategy($cacheOption)), 'cache');
         } elseif (!$this->_loggedCacheNotice) {
             $this->_logger->info("GuzzleFeatureRequester is not using an HTTP cache because Kevinrob\GuzzleCache\CacheMiddleware was not installed");
             $this->_loggedCacheNotice = true;


### PR DESCRIPTION
I have to define my own TTL cache (via guzzle) so I need to use a different CacheStrategyInterface (GreedyCacheStrategy and not PublicCacheStrategy)

Example of use :
```
return new LDClient(config('services.launchdarkly.key'), [
    'timeout'           => 3,
    'connect_timeout'   => 3,
    // cache redis
    'cache'             => new GreedyCacheStrategy(
        new LaravelCacheStorage(
            \Cache::store('redis')
        ),
        3600
    ),
]);
```

Can you accept this PR as soon as possible please ? (we need to put it in production)