### PR TITLE
Fix setting a Redis instance via config

### DIFF
--- a/src/LaunchDarkly/Impl/Integrations/PHPRedisFeatureRequester.php
+++ b/src/LaunchDarkly/Impl/Integrations/PHPRedisFeatureRequester.php
@@ -19,7 +19,7 @@ class PHPRedisFeatureRequester extends FeatureRequesterBase
         $this->_prefix = isset($options['redis_prefix']) ? $options['redis_prefix'] : 'launchdarkly';
 
         if (isset($this->_options['phpredis_client']) && $this->_options['phpredis_client'] instanceof Redis) {
-            $this->_connection = $this->_options['phpredis_client'];
+            $this->_redisInstance = $this->_options['phpredis_client'];
         } else {
             $this->_redisOptions = array(
                 "timeout" => isset($options['redis_timeout']) ? $options['redis_timeout'] : 5,


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

https://github.com/launchdarkly/php-server-sdk/issues/142

**Describe the solution you've provided**
It sets the $this->_connection parameter in `\LaunchDarkly\Impl\Integrations\PHPRedisFeatureRequester`, but the class uses `$this->_redisInstance`.

I've renamed the parameter set in the constructor accordingly.
