### PR TITLE
Fix bug with providing Redis Client

### DIFF
--- a/src/LaunchDarkly/Impl/Integrations/PHPRedisFeatureRequester.php
+++ b/src/LaunchDarkly/Impl/Integrations/PHPRedisFeatureRequester.php
@@ -18,7 +18,7 @@ class PHPRedisFeatureRequester extends FeatureRequesterBase
 
         $this->_prefix = isset($options['redis_prefix']) ? $options['redis_prefix'] : 'launchdarkly';
 
-        if (isset($this->_options['phpredis_client']) && $this->_options['phpredis_client'] instanceof Redis) {
+        if (isset($this->_options['phpredis_client']) && $this->_options['phpredis_client'] instanceof \Redis) {
             $this->_redisInstance = $this->_options['phpredis_client'];
         } else {
             $this->_redisOptions = array(
@@ -47,7 +47,7 @@ class PHPRedisFeatureRequester extends FeatureRequesterBase
      */
     protected function getConnection()
     {
-        if ($this->_redisInstance instanceof Redis) {
+        if ($this->_redisInstance instanceof \Redis) {
             return $this->_redisInstance;
         }
 


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

#150

**Describe the solution you've provided**

Prefixing `Redis` with a backslash to make it `\Redis` will resolve the issue, as explained in #150.

**Describe alternatives you've considered**

N/A

**Additional context**

I [did try writing a test](https://github.com/CameronHall/php-server-sdk/commit/a733ecc96c5e9f646f842a6e0fbf583d06283bf0#diff-71ff3b10ed22ffc31b1524c45b984854be92ae14590edf19b99b8a1deb78b0a3). Unfortunately, it kept failing on PHP 7.0 and 7.1. I stuffed about with it for a little while but I think it's time for bed 🥱 
