### PR TITLE
Issue #160 - use setVersion on update of a changed flag

### DIFF
--- a/src/LaunchDarkly/Integrations/TestData.php
+++ b/src/LaunchDarkly/Integrations/TestData.php
@@ -110,7 +110,7 @@ class TestData implements FeatureRequester
 
         $oldFlag = $this->_currentFlags[$key] ?? null;
         if ($oldFlag) {
-            $oldVersion = $oldFlag['version'];
+            $oldVersion = $oldFlag->getVersion();
         }
 
         $newFlag = $flagBuilder->build($oldVersion + 1);

--- a/tests/Integrations/TestDataTest.php
+++ b/tests/Integrations/TestDataTest.php
@@ -430,6 +430,37 @@ class TestDataTest extends TestCase
         $this->assertEquals($expectedFeatureFlag, $featureFlag);
     }
 
+    public function testCanSetAndResetFeatureFlag()
+    {
+        $key = 'test-flag';
+        $expectedUpdatedFlagJson = [
+            'key' => $key,
+            'version' => 2,
+            'deleted' => false,
+            'on' => true,
+            'targets' => [],
+            'rules' => [],
+            'offVariation' => 1,
+            'fallthrough' => ['variation' => 2],
+            'variations' => ['red', 'amber', 'green'],
+
+            /* Required FeatureFlag fields */
+            'salt' => null,
+            'prerequisites' => [],
+        ];
+        $expectedUpdatedFeatureFlag = FeatureFlag::decode($expectedUpdatedFlagJson);
+
+        $td = new TestData();
+        $flag = $td->flag($key);
+        $td->update($flag);
+        
+        $updatedFlag = $flag->variations('red', 'amber', 'green')->fallthroughVariation(2);
+        $td->update($updatedFlag);
+
+        $featureFlag = $td->getFeature($key);
+        $this->assertEquals($expectedUpdatedFeatureFlag, $featureFlag);
+    }
+
     public function testFlagBuilderCanAddAndBuildRules()
     {
         $td = new TestData();


### PR DESCRIPTION
**Requirements**

- [Y] I have added test coverage for new or changed functionality
- [Y] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [Y] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.
- fix for https://github.com/launchdarkly/php-server-sdk/issues/160

**Describe the solution you've provided**
- in TestData::update when flag is being copied from previous version - use setVersion rather than ['version'] to avoid generated error

Provide a clear and concise description of what you expect to happen.
- this allows the changed flag to be updated correctly without error and the new definition to be accessible

**Describe alternatives you've considered**

- no alternative considered.

**Additional context**

Add any other context about the pull request here.
- associated unit test to update an initial flag, change the flag and update it again
- unit-tested using docker for php 7.3, 7.4, 8.0, 8.1
