### PR TITLE
Improve error logging

### DIFF
--- a/src/LaunchDarkly/Impl/Util.php
+++ b/src/LaunchDarkly/Impl/Util.php
@@ -59,7 +59,13 @@ class Util
 
     public static function logExceptionAtErrorLevel(LoggerInterface $logger, \Throwable $e, string $message): void
     {
-        $logger->error($message . ': ' . $e->getMessage());
+        $logger->error(
+            $message . ': ' . $e->getMessage(),
+            [
+                'exception' => $e,
+            ]
+        );
+
         $logger->debug("$e");
     }
 

--- a/src/LaunchDarkly/Impl/Util.php
+++ b/src/LaunchDarkly/Impl/Util.php
@@ -65,8 +65,6 @@ class Util
                 'exception' => $e,
             ]
         );
-
-        $logger->debug("$e");
     }
 
     public static function makeNullLogger(): LoggerInterface


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

Various logging tools can generate a stack trace based on the exception being on the 'exception' key in the logging context. See [PSR-3](https://www.php-fig.org/psr/psr-3/#13-context)

**Describe alternatives you've considered**

We could keep the `debug` log but since this introduces duplicate logging and does not provide a browsable context of the exception, it is better to remove this.


I am a bit conflicted about keeping `$e->getMessage()` as part of the error message, since this becomes redundant with the same reason as before, many logging tools simply use the exception on the logging context already and use it as a message.
