### PR TITLE
Log flag when invalid context was used for flag evaluation

### DIFF
--- a/src/LaunchDarkly/LDClient.php
+++ b/src/LaunchDarkly/LDClient.php
@@ -247,7 +247,14 @@ class LDClient
             $result = $errorDetail(EvaluationReason::USER_NOT_SPECIFIED_ERROR);
             $sendEvent(new EvalResult($result, false), null);
             $error = $context->getError();
-            $this->_logger->warning("Context was invalid for flag evaluation ($error); returning default value");
+
+            $this->_logger->warning(
+                "Context was invalid for flag evaluation ($error); returning default value",
+                [
+                    'flag' => $key,
+                ]
+            );
+
             return $result;
         }
 


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

The warning message says what is going wrong, but not for what it is going wrong.
Adding a `flag` context value will help finding out which exact feature flag is having an invalid context

**Describe alternatives you've considered**

We could add this to the message but it is always better to use the logging context, see [PSR-3](https://www.php-fig.org/psr/psr-3/#13-context)