### PR TITLE
bug: Reduce the chance of `CurlEventPublisher` exhausting file descriptors on high throughput PHP-FPM servers

### DIFF
--- a/src/LaunchDarkly/Impl/Integrations/CurlEventPublisher.php
+++ b/src/LaunchDarkly/Impl/Integrations/CurlEventPublisher.php
@@ -80,7 +80,7 @@ class CurlEventPublisher implements EventPublisher
     {
         $scheme = $this->_ssl ? "https://" : "http://";
         $args = " -X POST";
-        $args.= " --connect-timeout " . $this->_connectTimeout;
+        $args.= " --max-time " . $this->_connectTimeout;
 
         foreach ($this->_eventHeaders as $key => $value) {
             if ($key == 'Authorization') {


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

I'm not aware of any.

**Describe the solution you've provided**

**TLDR:** `--connect-timeout` vs `--max-time` ([docs](https://curl.se/docs/manpage.html))

---

Consider the following code:

```php
function curl()
{
    shell_exec("/usr/bin/env curl -X POST --connect-timeout 3 -H 'Content-Type: application/json' -H 'Accept: application/json' https://reqres.in/api/users?delay=30" . " >> /dev/null 2>&1 &");
}
```

\+

```bash
while true; do   echo "$(date +"%H:%M:%S") - Open files: $(lsof | wc -l)";   sleep 0.5; done
```

However long the request takes is how long file descriptors hang open for.

Web apps like Laravel frequently use PHP-FPM as part of their server infrastructure where each request is a new process. On high throughput servers you generally have many worker processes, which means new sub-processes consume several file descriptors. As a result, on high throughput servers [EventProcessor.php::__destruct](https://github.com/launchdarkly/php-server-sdk/blob/491edd89d5d4c3e522d1e012293dcfd0c8abd546/src/LaunchDarkly/Impl/Events/EventProcessor.php#L35) gets invoked quite frequently. While the Relay Proxy is great at making quick read requests to data stores like Redis, the event processing system ends up quickly bottle-necking if there's any slow-down in receiving these events.

**Describe alternatives you've considered**

I think ideally:
1. `CurlEventPublisher` should use the actual `curl` client or something like `Guzzle` for making async requests instead of using `shell_exec`.
2. That `CurlEventPublisher` should possibly explore batch requesting strategies that won't choke out technologies like PHP-FPM. With more consideration for making sure these processes terminate - like logging warnings when it happens.

I ultimately stuck with a simple change to minimize the chance of it being a breaking change.

**Additional context**

This is related to an issue I filed a bit ago: https://support.launchdarkly.com/hc/en-us/requests/87721