### PR TITLE
fix: php 8.4 deprecation for implicitly nullable parameters

### DIFF
--- a/src/LaunchDarkly/EvaluationReason.php
+++ b/src/LaunchDarkly/EvaluationReason.php
@@ -166,7 +166,7 @@ class EvaluationReason implements \JsonSerializable
         ?string $ruleId = null,
         ?string $prerequisiteKey = null,
         bool $inExperiment = false,
-        BigSegmentsEvaluationStatus $bigSegmentsEvaluationStatus = null
+        ?BigSegmentsEvaluationStatus $bigSegmentsEvaluationStatus = null
     ) {
         $this->_kind = $kind;
         $this->_errorKind = $errorKind;

--- a/src/LaunchDarkly/Impl/Evaluation/EvalResult.php
+++ b/src/LaunchDarkly/Impl/Evaluation/EvalResult.php
@@ -22,7 +22,7 @@ class EvalResult
      * @param EvaluationDetail $detail
      * @param bool $forceReasonTracking
      */
-    public function __construct(EvaluationDetail $detail, bool $forceReasonTracking = false, EvaluatorState $state = null)
+    public function __construct(EvaluationDetail $detail, bool $forceReasonTracking = false, ?EvaluatorState $state = null)
     {
         $this->_detail = $detail;
         $this->_state = $state;


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

- https://github.com/launchdarkly/php-server-sdk/issues/218

**Describe the solution you've provided**

Add explicit nullable on related parameters.

**Describe alternatives you've considered**

Depending your code convention, `null|*` syntax could be used, but I saw that you use `?*` syntax on others files when object can be nullable. 

**Additional context**

N/A
