### PR TITLE
feat: add hooks support

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.15.1@28dc127af1b5aecd52314f6f645bafc10d0e11f9">
+<files psalm-version="6.16.1@f1f5de594dc76faf8784e02d3dc4716c91c6f6ac">
   <file src="src/LaunchDarkly/EvaluationDetail.php">
     <ClassMustBeFinal>
       <code><![CDATA[EvaluationDetail]]></code>
@@ -44,6 +44,33 @@
       <code><![CDATA[$meta['reason'] ?? null]]></code>
       <code><![CDATA[$prerequisites]]></code>
     </RiskyTruthyFalsyComparison>
+  </file>
+  <file src="src/LaunchDarkly/Hooks/EvaluationSeriesContext.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$context]]></code>
+      <code><![CDATA[$defaultValue]]></code>
+      <code><![CDATA[$method]]></code>
+    </PossiblyUnusedProperty>
+  </file>
+  <file src="src/LaunchDarkly/Hooks/Hook.php">
+    <PossiblyUnusedParam>
+      <code><![CDATA[$detail]]></code>
+      <code><![CDATA[$seriesContext]]></code>
+      <code><![CDATA[$seriesContext]]></code>
+      <code><![CDATA[$seriesContext]]></code>
+    </PossiblyUnusedParam>
+  </file>
+  <file src="src/LaunchDarkly/Hooks/Metadata.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="src/LaunchDarkly/Hooks/TrackSeriesContext.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$context]]></code>
+      <code><![CDATA[$data]]></code>
+      <code><![CDATA[$metricValue]]></code>
+    </PossiblyUnusedProperty>
   </file>
   <file src="src/LaunchDarkly/Impl/BigSegments/MembershipResult.php">
     <ClassMustBeFinal>
@@ -157,6 +184,9 @@
       <code><![CDATA[public function enqueue(array $event): bool]]></code>
       <code><![CDATA[public function flush(): bool]]></code>
     </MissingOverrideAttribute>
+    <UnusedClass>
+      <code><![CDATA[NullEventProcessor]]></code>
+    </UnusedClass>
   </file>
   <file src="src/LaunchDarkly/Impl/Integrations/ApcuFeatureRequesterCache.php">
     <ClassMustBeFinal>
@@ -451,6 +481,7 @@
     </ClassMustBeFinal>
     <PossiblyUnusedMethod>
       <code><![CDATA[__construct]]></code>
+      <code><![CDATA[addHook]]></code>
       <code><![CDATA[allFlagsState]]></code>
       <code><![CDATA[flush]]></code>
       <code><![CDATA[getBigSegmentStatusProvider]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -184,9 +184,6 @@
       <code><![CDATA[public function enqueue(array $event): bool]]></code>
       <code><![CDATA[public function flush(): bool]]></code>
     </MissingOverrideAttribute>
-    <UnusedClass>
-      <code><![CDATA[NullEventProcessor]]></code>
-    </UnusedClass>
   </file>
   <file src="src/LaunchDarkly/Impl/Integrations/ApcuFeatureRequesterCache.php">
     <ClassMustBeFinal>

--- a/src/LaunchDarkly/Hooks/EvaluationSeriesContext.php
+++ b/src/LaunchDarkly/Hooks/EvaluationSeriesContext.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaunchDarkly\Hooks;
+
+use LaunchDarkly\LDContext;
+
+/**
+ * Contextual information provided to stages of the evaluation series.
+ *
+ * An instance is created once per variation call and passed, unchanged, to every
+ * stage of every registered hook for that call.
+ */
+final class EvaluationSeriesContext
+{
+    public function __construct(
+        public readonly string $flagKey,
+        public readonly LDContext $context,
+        public readonly mixed $defaultValue,
+        public readonly string $method,
+    ) {
+    }
+}

--- a/src/LaunchDarkly/Hooks/Hook.php
+++ b/src/LaunchDarkly/Hooks/Hook.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaunchDarkly\Hooks;
+
+use LaunchDarkly\EvaluationDetail;
+
+/**
+ * Base class for extending SDK functionality via hooks.
+ *
+ * Hook implementations MUST inherit from this class. Default no-op
+ * implementations are provided for every stage so the SDK can add new stages
+ * without breaking existing implementations.
+ *
+ * Only `getMetadata` is abstract; subclasses override just the stages they need.
+ */
+abstract class Hook
+{
+    /**
+     * Get metadata about the hook implementation.
+     */
+    abstract public function getMetadata(): Metadata;
+
+    /**
+     * Stage executed before the flag value has been determined.
+     *
+     * Called synchronously on the thread performing the variation call.
+     *
+     * @param array<string, mixed> $data Data returned by the previous stage of this hook.
+     *     For beforeEvaluation this will be an empty array.
+     * @return array<string, mixed> Data to be passed to the next stage of this hook.
+     *     Implementations should return the input data (optionally augmented) unchanged
+     *     if they do not need to pass additional information forward.
+     */
+    public function beforeEvaluation(EvaluationSeriesContext $seriesContext, array $data): array
+    {
+        return $data;
+    }
+
+    /**
+     * Stage executed after the flag value has been determined.
+     *
+     * Called synchronously on the thread performing the variation call.
+     *
+     * @param array<string, mixed> $data Data returned by the beforeEvaluation stage of this hook.
+     * @param EvaluationDetail $detail The result of the evaluation. This value should not be modified.
+     * @return array<string, mixed> Data to be passed to the next stage of this hook.
+     *     The return is currently unused but future stages may consume it.
+     */
+    public function afterEvaluation(
+        EvaluationSeriesContext $seriesContext,
+        array $data,
+        EvaluationDetail $detail,
+    ): array {
+        return $data;
+    }
+
+    /**
+     * Handler executed after a custom event has been enqueued by a call to `track`.
+     *
+     * Not invoked if the track call could not enqueue an event (e.g. invalid context).
+     */
+    public function afterTrack(TrackSeriesContext $seriesContext): void
+    {
+    }
+}

--- a/src/LaunchDarkly/Hooks/Metadata.php
+++ b/src/LaunchDarkly/Hooks/Metadata.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaunchDarkly\Hooks;
+
+/**
+ * Metadata about a hook implementation.
+ */
+final class Metadata
+{
+    public function __construct(
+        public readonly string $name,
+    ) {
+    }
+}

--- a/src/LaunchDarkly/Hooks/TrackSeriesContext.php
+++ b/src/LaunchDarkly/Hooks/TrackSeriesContext.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaunchDarkly\Hooks;
+
+use LaunchDarkly\LDContext;
+
+/**
+ * Contextual information provided to the afterTrack stage of the track series.
+ */
+final class TrackSeriesContext
+{
+    public function __construct(
+        public readonly LDContext $context,
+        public readonly string $key,
+        public readonly int|float|null $metricValue,
+        public readonly mixed $data,
+    ) {
+    }
+}

--- a/src/LaunchDarkly/Impl/Hooks/HookRunner.php
+++ b/src/LaunchDarkly/Impl/Hooks/HookRunner.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaunchDarkly\Impl\Hooks;
+
+use LaunchDarkly\EvaluationDetail;
+use LaunchDarkly\Hooks\EvaluationSeriesContext;
+use LaunchDarkly\Hooks\Hook;
+use LaunchDarkly\Hooks\TrackSeriesContext;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * @ignore
+ * @internal
+ *
+ * Runs hook stages with the required ordering and error isolation behavior.
+ */
+final class HookRunner
+{
+    /** @var list<Hook> */
+    private array $_hooks;
+
+    /**
+     * @param list<Hook> $hooks
+     */
+    public function __construct(
+        private readonly LoggerInterface $_logger,
+        array $hooks = [],
+    ) {
+        $this->_hooks = $hooks;
+    }
+
+    public function addHook(Hook $hook): void
+    {
+        $this->_hooks[] = $hook;
+    }
+
+    public function hasHooks(): bool
+    {
+        return count($this->_hooks) > 0;
+    }
+
+    /**
+     * Executes the beforeEvaluation stage of every registered hook in registration order.
+     *
+     * @return list<array<string, mixed>> The data returned by each hook, in the same order as
+     *     the registered hooks. On error, the slot for that hook contains an empty array.
+     */
+    public function beforeEvaluation(EvaluationSeriesContext $seriesContext): array
+    {
+        $result = [];
+        foreach ($this->_hooks as $hook) {
+            $result[] = $this->safeInvoke(
+                'beforeEvaluation',
+                $seriesContext->flagKey,
+                $hook,
+                fn () => $hook->beforeEvaluation($seriesContext, []),
+                [],
+            );
+        }
+        return $result;
+    }
+
+    /**
+     * Executes the afterEvaluation stage of every registered hook in reverse registration order.
+     *
+     * @param list<array<string, mixed>> $beforeData The per-hook data returned from beforeEvaluation.
+     */
+    public function afterEvaluation(
+        EvaluationSeriesContext $seriesContext,
+        array $beforeData,
+        EvaluationDetail $detail,
+    ): void {
+        for ($i = count($this->_hooks) - 1; $i >= 0; $i--) {
+            $hook = $this->_hooks[$i];
+            $data = $beforeData[$i] ?? [];
+            $this->safeInvoke(
+                'afterEvaluation',
+                $seriesContext->flagKey,
+                $hook,
+                fn () => $hook->afterEvaluation($seriesContext, $data, $detail),
+                $data,
+            );
+        }
+    }
+
+    /**
+     * Executes the afterTrack handler of every registered hook in registration order.
+     */
+    public function afterTrack(TrackSeriesContext $seriesContext): void
+    {
+        foreach ($this->_hooks as $hook) {
+            try {
+                $hook->afterTrack($seriesContext);
+            } catch (Throwable $e) {
+                $name = $this->hookName($hook);
+                $this->_logger->error(
+                    "During tracking of event \"{$seriesContext->key}\", stage \"afterTrack\" of hook \"{$name}\" reported error: {$e->getMessage()}"
+                );
+            }
+        }
+    }
+
+    /**
+     * @template T
+     * @param callable(): T $fn
+     * @param T $fallback
+     * @return T
+     */
+    private function safeInvoke(string $stage, string $flagKey, Hook $hook, callable $fn, mixed $fallback): mixed
+    {
+        try {
+            return $fn();
+        } catch (Throwable $e) {
+            $name = $this->hookName($hook);
+            $this->_logger->error(
+                "During evaluation of flag \"{$flagKey}\", stage \"{$stage}\" of hook \"{$name}\" reported error: {$e->getMessage()}"
+            );
+            return $fallback;
+        }
+    }
+
+    private function hookName(Hook $hook): string
+    {
+        try {
+            return $hook->getMetadata()->name;
+        } catch (Throwable) {
+            return 'unknown hook';
+        }
+    }
+}

--- a/src/LaunchDarkly/LDClient.php
+++ b/src/LaunchDarkly/LDClient.php
@@ -365,9 +365,18 @@ class LDClient
 
         $seriesContext = new EvaluationSeriesContext($key, $context, $default, $method);
         $beforeData = $this->_hookRunner->beforeEvaluation($seriesContext);
-        $result = $this->evaluateInternal($key, $context, $default, $eventFactory);
-        $this->_hookRunner->afterEvaluation($seriesContext, $beforeData, $result['detail']);
-        return $result;
+
+        // Default to an exception-error detail so afterEvaluation still fires (spec 1.3.4)
+        // if evaluateInternal propagates a \Throwable that evaluateInternal's own catch(\Exception)
+        // did not handle (e.g. a \TypeError).
+        $detail = new EvaluationDetail($default, null, EvaluationReason::error(EvaluationReason::EXCEPTION_ERROR));
+        try {
+            $result = $this->evaluateInternal($key, $context, $default, $eventFactory);
+            $detail = $result['detail'];
+            return $result;
+        } finally {
+            $this->_hookRunner->afterEvaluation($seriesContext, $beforeData, $detail);
+        }
     }
 
     /**

--- a/src/LaunchDarkly/LDClient.php
+++ b/src/LaunchDarkly/LDClient.php
@@ -365,18 +365,9 @@ class LDClient
 
         $seriesContext = new EvaluationSeriesContext($key, $context, $default, $method);
         $beforeData = $this->_hookRunner->beforeEvaluation($seriesContext);
-
-        // Default to an exception-error detail so afterEvaluation still fires (spec 1.3.4)
-        // if evaluateInternal propagates a \Throwable that evaluateInternal's own catch(\Exception)
-        // did not handle (e.g. a \TypeError).
-        $detail = new EvaluationDetail($default, null, EvaluationReason::error(EvaluationReason::EXCEPTION_ERROR));
-        try {
-            $result = $this->evaluateInternal($key, $context, $default, $eventFactory);
-            $detail = $result['detail'];
-            return $result;
-        } finally {
-            $this->_hookRunner->afterEvaluation($seriesContext, $beforeData, $detail);
-        }
+        $result = $this->evaluateInternal($key, $context, $default, $eventFactory);
+        $this->_hookRunner->afterEvaluation($seriesContext, $beforeData, $result['detail']);
+        return $result;
     }
 
     /**
@@ -456,7 +447,7 @@ class LDClient
             }
             $sendEvent($evalResult, $flag);
             return ['detail' => $detail, 'flag' => $flag];
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Util::logExceptionAtErrorLevel($this->_logger, $e, "Unexpected error evaluating flag $key");
             $result = $errorDetail(EvaluationReason::EXCEPTION_ERROR);
             $sendEvent(new EvalResult($result, false), null);

--- a/src/LaunchDarkly/LDClient.php
+++ b/src/LaunchDarkly/LDClient.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace LaunchDarkly;
 
+use LaunchDarkly\Hooks\EvaluationSeriesContext;
+use LaunchDarkly\Hooks\Hook;
+use LaunchDarkly\Hooks\TrackSeriesContext;
 use LaunchDarkly\Impl\BigSegments;
 use LaunchDarkly\Impl\Evaluation\EvalResult;
 use LaunchDarkly\Impl\Evaluation\Evaluator;
@@ -11,6 +14,7 @@ use LaunchDarkly\Impl\Evaluation\PrerequisiteEvaluationRecord;
 use LaunchDarkly\Impl\Events\EventFactory;
 use LaunchDarkly\Impl\Events\EventProcessor;
 use LaunchDarkly\Impl\Events\NullEventProcessor;
+use LaunchDarkly\Impl\Hooks\HookRunner;
 use LaunchDarkly\Impl\Model\FeatureFlag;
 use LaunchDarkly\Impl\PreloadedFeatureRequester;
 use LaunchDarkly\Impl\UnrecoverableHTTPStatusException;
@@ -56,6 +60,7 @@ class LDClient
     protected EventFactory $_eventFactoryWithReasons;
     protected BigSegments\StoreManager $_bigSegmentsStoreManager;
     protected BigSegmentStatusProvider $_bigSegmentStatusProvider;
+    protected HookRunner $_hookRunner;
 
     /**
      * Creates a new client instance that connects to LaunchDarkly.
@@ -87,6 +92,9 @@ class LDClient
      * - `wrapper_name`: For use by wrapper libraries to set an identifying name for the wrapper being used. This will be sent in User-Agent headers during requests to the LaunchDarkly servers to allow recording metrics on the usage of these wrapper libraries.
      * - `wrapper_version`: For use by wrapper libraries to report the version of the library in use. If `wrapper_name` is not set, this field will be ignored. Otherwise the version string will be included in the User-Agent headers along with the `wrapper_name` during requests to the LaunchDarkly servers.
      * - `big_segments`: An option {@see \LaunchDarkly\Types\BigSegmentsConfig} instance.
+     * - `hooks`: An optional list of {@see \LaunchDarkly\Hooks\Hook} implementations. Entries that are not Hook
+     * instances are logged and ignored. Additional hooks can be registered after construction via
+     * {@see \LaunchDarkly\LDClient::addHook()}.
      * - Other options may be available depending on any features you are using from the `LaunchDarkly\Integrations` namespace.
      *
      * @return LDClient
@@ -178,6 +186,28 @@ class LDClient
         $this->_featureRequester = $this->getFeatureRequester($sdkKey, $options);
 
         $this->_evaluator = new Evaluator($this->_featureRequester, $this->_bigSegmentsStoreManager, $this->_logger);
+
+        $hooks = [];
+        foreach ($options['hooks'] ?? [] as $hook) {
+            if ($hook instanceof Hook) {
+                $hooks[] = $hook;
+            } else {
+                $this->_logger->warning("Ignoring non-Hook entry in 'hooks' option");
+            }
+        }
+        $this->_hookRunner = new HookRunner($this->_logger, $hooks);
+    }
+
+    /**
+     * Registers a hook with the client.
+     *
+     * Hooks registered here are invoked in addition to any hooks provided via the `hooks`
+     * constructor option. Prefer the constructor option for hooks that need to observe every
+     * evaluation from the start of the client's lifetime.
+     */
+    public function addHook(Hook $hook): void
+    {
+        $this->_hookRunner->addHook($hook);
     }
 
     public function getLogger(): LoggerInterface
@@ -240,7 +270,7 @@ class LDClient
      */
     public function variation(string $key, LDContext $context, mixed $defaultValue = false): mixed
     {
-        $detail = $this->variationDetailInternal($key, $context, $defaultValue, $this->_eventFactoryDefault)['detail'];
+        $detail = $this->variationDetailInternal($key, $context, $defaultValue, $this->_eventFactoryDefault, 'variation')['detail'];
         return $detail->getValue();
     }
 
@@ -260,7 +290,7 @@ class LDClient
      */
     public function variationDetail(string $key, LDContext $context, mixed $defaultValue = false): EvaluationDetail
     {
-        return $this->variationDetailInternal($key, $context, $defaultValue, $this->_eventFactoryWithReasons)['detail'];
+        return $this->variationDetailInternal($key, $context, $defaultValue, $this->_eventFactoryWithReasons, 'variationDetail')['detail'];
     }
 
     /**
@@ -276,7 +306,7 @@ class LDClient
      */
     public function migrationVariation(string $key, LDContext $context, Stage $defaultStage): array
     {
-        $result = $this->variationDetailInternal($key, $context, $defaultStage->value, $this->_eventFactoryDefault);
+        $result = $this->variationDetailInternal($key, $context, $defaultStage->value, $this->_eventFactoryDefault, 'migrationVariation');
         $detail = $result['detail'];
         $flag = $result['flag'];
 
@@ -321,13 +351,37 @@ class LDClient
      * @param LDContext $context
      * @param mixed $default
      * @param EventFactory $eventFactory
+     * @param string $method Name of the calling public variation method, passed to hooks.
      *
      * @psalm-return array{'detail': EvaluationDetail, 'flag': ?FeatureFlag}
      */
-    private function variationDetailInternal(string $key, LDContext $context, mixed $default, EventFactory $eventFactory): array
+    private function variationDetailInternal(string $key, LDContext $context, mixed $default, EventFactory $eventFactory, string $method): array
     {
         $default = $this->_get_default($key, $default);
 
+        if (!$this->_hookRunner->hasHooks()) {
+            return $this->evaluateInternal($key, $context, $default, $eventFactory);
+        }
+
+        $seriesContext = new EvaluationSeriesContext($key, $context, $default, $method);
+        $beforeData = $this->_hookRunner->beforeEvaluation($seriesContext);
+        $result = $this->evaluateInternal($key, $context, $default, $eventFactory);
+        $this->_hookRunner->afterEvaluation($seriesContext, $beforeData, $result['detail']);
+        return $result;
+    }
+
+    /**
+     * Core evaluation logic, wrapped by {@see variationDetailInternal} which adds hook execution.
+     *
+     * @param string $key
+     * @param LDContext $context
+     * @param mixed $default
+     * @param EventFactory $eventFactory
+     *
+     * @psalm-return array{'detail': EvaluationDetail, 'flag': ?FeatureFlag}
+     */
+    private function evaluateInternal(string $key, LDContext $context, mixed $default, EventFactory $eventFactory): array
+    {
         $errorDetail = fn (string $errorKind): EvaluationDetail =>
             new EvaluationDetail($default, null, EvaluationReason::error($errorKind));
         $sendEvent = function (EvalResult $result, ?FeatureFlag $flag) use ($key, $context, $default, $eventFactory): void {
@@ -432,6 +486,10 @@ class LDClient
             return;
         }
         $this->_eventProcessor->enqueue($this->_eventFactoryDefault->newCustomEvent($eventName, $context, $data, $metricValue));
+
+        if ($this->_hookRunner->hasHooks()) {
+            $this->_hookRunner->afterTrack(new TrackSeriesContext($context, $eventName, $metricValue, $data));
+        }
     }
 
     /**

--- a/test-service/PostingHook.php
+++ b/test-service/PostingHook.php
@@ -14,7 +14,7 @@ use LaunchDarkly\Hooks\TrackSeriesContext;
 
 /**
  * Contract-test hook. Posts each stage invocation to a callback URL; optionally throws
- * from configured stages. Parallels the hook implementations in the other SDKs'
+ * from configured stages.
  * contract test services.
  */
 class PostingHook extends Hook

--- a/test-service/PostingHook.php
+++ b/test-service/PostingHook.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Exception;
+use GuzzleHttp\Client;
+use LaunchDarkly\EvaluationDetail;
+use LaunchDarkly\Hooks\EvaluationSeriesContext;
+use LaunchDarkly\Hooks\Hook;
+use LaunchDarkly\Hooks\Metadata;
+use LaunchDarkly\Hooks\TrackSeriesContext;
+
+/**
+ * Contract-test hook. Posts each stage invocation to a callback URL; optionally throws
+ * from configured stages. Parallels the hook implementations in the other SDKs'
+ * contract test services.
+ */
+class PostingHook extends Hook
+{
+    public function __construct(
+        private readonly string $name,
+        private readonly string $callbackUri,
+        private readonly array $data,
+        private readonly array $errors,
+    ) {
+    }
+
+    public function getMetadata(): Metadata
+    {
+        return new Metadata($this->name);
+    }
+
+    public function beforeEvaluation(EvaluationSeriesContext $seriesContext, array $data): array
+    {
+        return $this->post('beforeEvaluation', $seriesContext, $data, null);
+    }
+
+    public function afterEvaluation(
+        EvaluationSeriesContext $seriesContext,
+        array $data,
+        EvaluationDetail $detail,
+    ): array {
+        return $this->post('afterEvaluation', $seriesContext, $data, $detail);
+    }
+
+    public function afterTrack(TrackSeriesContext $seriesContext): void
+    {
+        $stage = 'afterTrack';
+        if (isset($this->errors[$stage])) {
+            throw new Exception($this->errors[$stage]);
+        }
+        $payload = [
+            'stage' => $stage,
+            'trackSeriesContext' => [
+                'key' => $seriesContext->key,
+                'context' => json_decode(json_encode($seriesContext->context), true),
+                'data' => $seriesContext->data,
+                'metricValue' => $seriesContext->metricValue,
+            ],
+        ];
+        (new Client())->post($this->callbackUri, ['json' => $payload]);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return array<string, mixed>
+     */
+    private function post(
+        string $stage,
+        EvaluationSeriesContext $seriesContext,
+        array $data,
+        ?EvaluationDetail $detail,
+    ): array {
+        if (isset($this->errors[$stage])) {
+            throw new Exception($this->errors[$stage]);
+        }
+
+        $payload = [
+            'evaluationSeriesContext' => [
+                'flagKey' => $seriesContext->flagKey,
+                'context' => json_decode(json_encode($seriesContext->context), true),
+                'defaultValue' => $seriesContext->defaultValue,
+                'method' => $seriesContext->method,
+            ],
+            'evaluationSeriesData' => (object) $data,
+            'stage' => $stage,
+        ];
+
+        if ($detail !== null) {
+            $payload['evaluationDetail'] = [
+                'value' => $detail->getValue(),
+                'variationIndex' => $detail->getVariationIndex(),
+                'reason' => $detail->getReason(),
+            ];
+        }
+
+        (new Client())->post($this->callbackUri, ['json' => $payload]);
+
+        return array_merge($data, $this->data[$stage] ?? []);
+    }
+}

--- a/test-service/SdkClientEntity.php
+++ b/test-service/SdkClientEntity.php
@@ -59,6 +59,19 @@ class SdkClientEntity
         $options['all_attributes_private'] = $eventsConfig['allAttributesPrivate'] ?? false;
         $options['private_attribute_names'] = $eventsConfig['globalPrivateAttributes'] ?? null;
 
+        $hooks = $config['hooks']['hooks'] ?? null;
+        if ($hooks) {
+            $options['hooks'] = array_map(
+                fn (array $h) => new PostingHook(
+                    $h['name'],
+                    $h['callbackUri'],
+                    $h['data'] ?? [],
+                    $h['errors'] ?? [],
+                ),
+                $hooks
+            );
+        }
+
         $bigSegments = $config['bigSegments'] ?? null;
         if ($bigSegments) {
             $store = new BigSegmentsStoreGuzzle(new Client(), $bigSegments['callbackUri']);

--- a/test-service/TestService.php
+++ b/test-service/TestService.php
@@ -80,7 +80,9 @@ class TestService
                 'instance-id',
                 'anonymous-redaction',
                 'client-prereq-events',
-                'big-segments'
+                'big-segments',
+                'evaluation-hooks',
+                'track-hooks'
             ],
             'clientVersion' => \LaunchDarkly\LDClient::VERSION
         ];

--- a/tests/Hooks/CallLog.php
+++ b/tests/Hooks/CallLog.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaunchDarkly\Tests\Hooks;
+
+/**
+ * Mutable shared log used by tests to observe the order in which multiple hooks are invoked.
+ * Wraps an array so callers can share a single instance across hooks.
+ */
+final class CallLog
+{
+    /** @var array<int, array<string, mixed>> */
+    public array $calls = [];
+
+    /**
+     * @param array<string, mixed> $entry
+     */
+    public function append(array $entry): void
+    {
+        $this->calls[] = $entry;
+    }
+}

--- a/tests/Hooks/HookRunnerTest.php
+++ b/tests/Hooks/HookRunnerTest.php
@@ -84,8 +84,10 @@ class HookRunnerTest extends TestCase
         $runner->afterEvaluation($this->ctx(), $before, $this->detail());
 
         // Hook A's afterEvaluation receives [] because its beforeEvaluation failed.
-        $this->assertSame([], $a->calls[0]['data']);
-        // Hook B is unaffected.
+        $this->assertSame('afterEvaluation', $a->calls[1]['stage']);
+        $this->assertSame([], $a->calls[1]['data']);
+        // Hook B is unaffected; its afterEvaluation sees the data returned from its beforeEvaluation.
+        $this->assertSame('afterEvaluation', $b->calls[1]['stage']);
         $this->assertSame(['from-b' => 2], $b->calls[1]['data']);
     }
 

--- a/tests/Hooks/HookRunnerTest.php
+++ b/tests/Hooks/HookRunnerTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaunchDarkly\Tests\Hooks;
+
+use LaunchDarkly\EvaluationDetail;
+use LaunchDarkly\EvaluationReason;
+use LaunchDarkly\Hooks\EvaluationSeriesContext;
+use LaunchDarkly\Hooks\TrackSeriesContext;
+use LaunchDarkly\Impl\Hooks\HookRunner;
+use LaunchDarkly\LDContext;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+class HookRunnerTest extends TestCase
+{
+    private function ctx(): EvaluationSeriesContext
+    {
+        return new EvaluationSeriesContext('flag-key', LDContext::create('u'), 'default', 'variation');
+    }
+
+    private function detail(): EvaluationDetail
+    {
+        return new EvaluationDetail('value', 0, EvaluationReason::fallthrough());
+    }
+
+    private function nullLogger(): LoggerInterface
+    {
+        return new \Psr\Log\NullLogger();
+    }
+
+    public function testBeforeEvaluationRunsInRegistrationOrder(): void
+    {
+        $shared = [];
+        $a = new RecordingHook('A', $shared);
+        $b = new RecordingHook('B', $shared);
+        $runner = new HookRunner($this->nullLogger(), [$a, $b]);
+
+        $runner->beforeEvaluation($this->ctx());
+
+        $this->assertSame(['A', 'B'], array_column($shared, 'hook'));
+    }
+
+    public function testAfterEvaluationRunsInReverseRegistrationOrder(): void
+    {
+        $shared = [];
+        $a = new RecordingHook('A', $shared);
+        $b = new RecordingHook('B', $shared);
+        $runner = new HookRunner($this->nullLogger(), [$a, $b]);
+
+        $before = $runner->beforeEvaluation($this->ctx());
+        $runner->afterEvaluation($this->ctx(), $before, $this->detail());
+
+        // beforeEvaluation: A, B; afterEvaluation: B, A.
+        $this->assertSame(
+            ['A:beforeEvaluation', 'B:beforeEvaluation', 'B:afterEvaluation', 'A:afterEvaluation'],
+            array_map(fn ($e) => $e['hook'] . ':' . $e['stage'], $shared),
+        );
+    }
+
+    public function testSeriesDataIsPropagatedPerHook(): void
+    {
+        $a = new RecordingHook('A', returnData: ['beforeEvaluation' => ['from-a' => 1]]);
+        $b = new RecordingHook('B', returnData: ['beforeEvaluation' => ['from-b' => 2]]);
+        $runner = new HookRunner($this->nullLogger(), [$a, $b]);
+
+        $before = $runner->beforeEvaluation($this->ctx());
+        $runner->afterEvaluation($this->ctx(), $before, $this->detail());
+
+        // Each hook sees only its own beforeEvaluation data.
+        $this->assertSame(['from-a' => 1], $a->calls[1]['data']);
+        $this->assertSame(['from-b' => 2], $b->calls[1]['data']);
+    }
+
+    public function testBeforeEvaluationErrorYieldsEmptyDataForThatHook(): void
+    {
+        $a = new RecordingHook('A', throwFrom: ['beforeEvaluation' => new RuntimeException('boom')]);
+        $b = new RecordingHook('B', returnData: ['beforeEvaluation' => ['from-b' => 2]]);
+        $runner = new HookRunner($this->nullLogger(), [$a, $b]);
+
+        $before = $runner->beforeEvaluation($this->ctx());
+        $runner->afterEvaluation($this->ctx(), $before, $this->detail());
+
+        // Hook A's afterEvaluation receives [] because its beforeEvaluation failed.
+        $this->assertSame([], $a->calls[0]['data']);
+        // Hook B is unaffected.
+        $this->assertSame(['from-b' => 2], $b->calls[1]['data']);
+    }
+
+    public function testAfterEvaluationErrorIsLoggedAndIsolated(): void
+    {
+        $a = new RecordingHook('A', throwFrom: ['afterEvaluation' => new RuntimeException('boom')]);
+        $b = new RecordingHook('B');
+        $runner = new HookRunner($this->nullLogger(), [$a, $b]);
+
+        $before = $runner->beforeEvaluation($this->ctx());
+        $runner->afterEvaluation($this->ctx(), $before, $this->detail());
+
+        // Both hooks' afterEvaluation still ran, despite A throwing.
+        $this->assertCount(2, $a->calls);
+        $this->assertCount(2, $b->calls);
+    }
+
+    public function testExceptionLoggedWithRequiredFormat(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with($this->equalTo('During evaluation of flag "flag-key", stage "beforeEvaluation" of hook "A" reported error: boom'));
+
+        $a = new RecordingHook('A', throwFrom: ['beforeEvaluation' => new RuntimeException('boom')]);
+        $runner = new HookRunner($logger, [$a]);
+        $runner->beforeEvaluation($this->ctx());
+    }
+
+    public function testAfterTrackRunsInRegistrationOrder(): void
+    {
+        $shared = [];
+        $a = new RecordingHook('A', $shared);
+        $b = new RecordingHook('B', $shared);
+        $runner = new HookRunner($this->nullLogger(), [$a, $b]);
+
+        $runner->afterTrack(new TrackSeriesContext(LDContext::create('u'), 'event', null, null));
+
+        $this->assertSame(['A', 'B'], array_column($shared, 'hook'));
+    }
+
+    public function testAfterTrackExceptionIsLoggedAndIsolated(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with($this->stringContains('stage "afterTrack" of hook "A" reported error: boom'));
+
+        $a = new RecordingHook('A', throwFrom: ['afterTrack' => new RuntimeException('boom')]);
+        $b = new RecordingHook('B');
+        $runner = new HookRunner($logger, [$a, $b]);
+
+        $runner->afterTrack(new TrackSeriesContext(LDContext::create('u'), 'event', null, null));
+
+        // B still runs after A throws.
+        $this->assertCount(1, $b->calls);
+    }
+
+    public function testAddHookAppendsToEndOfOrder(): void
+    {
+        $shared = [];
+        $a = new RecordingHook('A', $shared);
+        $runner = new HookRunner($this->nullLogger(), [$a]);
+
+        $b = new RecordingHook('B', $shared);
+        $runner->addHook($b);
+
+        $runner->beforeEvaluation($this->ctx());
+        $this->assertSame(['A', 'B'], array_column($shared, 'hook'));
+    }
+
+    public function testHasHooksReflectsRegistrationState(): void
+    {
+        $runner = new HookRunner($this->nullLogger(), []);
+        $this->assertFalse($runner->hasHooks());
+
+        $runner->addHook(new RecordingHook('A'));
+        $this->assertTrue($runner->hasHooks());
+    }
+}

--- a/tests/Hooks/HookRunnerTest.php
+++ b/tests/Hooks/HookRunnerTest.php
@@ -33,19 +33,19 @@ class HookRunnerTest extends TestCase
 
     public function testBeforeEvaluationRunsInRegistrationOrder(): void
     {
-        $shared = [];
+        $shared = new CallLog();
         $a = new RecordingHook('A', $shared);
         $b = new RecordingHook('B', $shared);
         $runner = new HookRunner($this->nullLogger(), [$a, $b]);
 
         $runner->beforeEvaluation($this->ctx());
 
-        $this->assertSame(['A', 'B'], array_column($shared, 'hook'));
+        $this->assertSame(['A', 'B'], array_column($shared->calls, 'hook'));
     }
 
     public function testAfterEvaluationRunsInReverseRegistrationOrder(): void
     {
-        $shared = [];
+        $shared = new CallLog();
         $a = new RecordingHook('A', $shared);
         $b = new RecordingHook('B', $shared);
         $runner = new HookRunner($this->nullLogger(), [$a, $b]);
@@ -56,7 +56,7 @@ class HookRunnerTest extends TestCase
         // beforeEvaluation: A, B; afterEvaluation: B, A.
         $this->assertSame(
             ['A:beforeEvaluation', 'B:beforeEvaluation', 'B:afterEvaluation', 'A:afterEvaluation'],
-            array_map(fn ($e) => $e['hook'] . ':' . $e['stage'], $shared),
+            array_map(fn ($e) => $e['hook'] . ':' . $e['stage'], $shared->calls),
         );
     }
 
@@ -117,14 +117,14 @@ class HookRunnerTest extends TestCase
 
     public function testAfterTrackRunsInRegistrationOrder(): void
     {
-        $shared = [];
+        $shared = new CallLog();
         $a = new RecordingHook('A', $shared);
         $b = new RecordingHook('B', $shared);
         $runner = new HookRunner($this->nullLogger(), [$a, $b]);
 
         $runner->afterTrack(new TrackSeriesContext(LDContext::create('u'), 'event', null, null));
 
-        $this->assertSame(['A', 'B'], array_column($shared, 'hook'));
+        $this->assertSame(['A', 'B'], array_column($shared->calls, 'hook'));
     }
 
     public function testAfterTrackExceptionIsLoggedAndIsolated(): void
@@ -146,7 +146,7 @@ class HookRunnerTest extends TestCase
 
     public function testAddHookAppendsToEndOfOrder(): void
     {
-        $shared = [];
+        $shared = new CallLog();
         $a = new RecordingHook('A', $shared);
         $runner = new HookRunner($this->nullLogger(), [$a]);
 
@@ -154,7 +154,7 @@ class HookRunnerTest extends TestCase
         $runner->addHook($b);
 
         $runner->beforeEvaluation($this->ctx());
-        $this->assertSame(['A', 'B'], array_column($shared, 'hook'));
+        $this->assertSame(['A', 'B'], array_column($shared->calls, 'hook'));
     }
 
     public function testHasHooksReflectsRegistrationState(): void

--- a/tests/Hooks/HookTest.php
+++ b/tests/Hooks/HookTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaunchDarkly\Tests\Hooks;
+
+use LaunchDarkly\EvaluationDetail;
+use LaunchDarkly\EvaluationReason;
+use LaunchDarkly\Hooks\EvaluationSeriesContext;
+use LaunchDarkly\Hooks\Hook;
+use LaunchDarkly\Hooks\Metadata;
+use LaunchDarkly\Hooks\TrackSeriesContext;
+use LaunchDarkly\LDContext;
+use PHPUnit\Framework\TestCase;
+
+class HookTest extends TestCase
+{
+    public function testDefaultBeforeEvaluationReturnsInputData(): void
+    {
+        $hook = new class extends Hook {
+            public function getMetadata(): Metadata
+            {
+                return new Metadata('test');
+            }
+        };
+
+        $ctx = new EvaluationSeriesContext('flag', LDContext::create('u'), false, 'variation');
+        $data = ['foo' => 'bar'];
+        $this->assertSame($data, $hook->beforeEvaluation($ctx, $data));
+    }
+
+    public function testDefaultAfterEvaluationReturnsInputData(): void
+    {
+        $hook = new class extends Hook {
+            public function getMetadata(): Metadata
+            {
+                return new Metadata('test');
+            }
+        };
+
+        $ctx = new EvaluationSeriesContext('flag', LDContext::create('u'), false, 'variation');
+        $detail = new EvaluationDetail(true, 0, EvaluationReason::off());
+        $data = ['foo' => 'bar'];
+        $this->assertSame($data, $hook->afterEvaluation($ctx, $data, $detail));
+    }
+
+    public function testDefaultAfterTrackIsNoOp(): void
+    {
+        $hook = new class extends Hook {
+            public function getMetadata(): Metadata
+            {
+                return new Metadata('test');
+            }
+        };
+
+        $ctx = new TrackSeriesContext(LDContext::create('u'), 'event', null, null);
+        // Simply invoking should not throw or have observable effects.
+        $hook->afterTrack($ctx);
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Hooks/LDClientHooksTest.php
+++ b/tests/Hooks/LDClientHooksTest.php
@@ -145,6 +145,37 @@ class LDClientHooksTest extends TestCase
         $this->assertSame('v', $value);
     }
 
+    public function testAfterEvaluationFiresEvenWhenEvaluationThrowsThrowable(): void
+    {
+        // evaluateInternal only catches \Exception, but spec 1.3.4 requires afterEvaluation
+        // to always run after beforeEvaluation. Simulate a non-Exception \Throwable
+        // propagating from the feature requester and assert afterEvaluation still fires
+        // with a detail whose reason indicates an exception.
+        $throwingRequester = new class extends MockFeatureRequester {
+            public function getFeature(string $key): ?\LaunchDarkly\Impl\Model\FeatureFlag
+            {
+                throw new \TypeError('synthetic');
+            }
+        };
+        $hook = new RecordingHook('A');
+        $client = $this->makeClient(['feature_requester' => $throwingRequester, 'hooks' => [$hook]]);
+
+        try {
+            $client->variation('flag', LDContext::create('u'), 'default');
+            $this->fail('expected TypeError to propagate');
+        } catch (\TypeError) {
+            // expected
+        }
+
+        $this->assertCount(2, $hook->calls);
+        $this->assertSame('beforeEvaluation', $hook->calls[0]['stage']);
+        $this->assertSame('afterEvaluation', $hook->calls[1]['stage']);
+        $this->assertSame(
+            EvaluationReason::EXCEPTION_ERROR,
+            $hook->calls[1]['detail']->getReason()->getErrorKind(),
+        );
+    }
+
     public function testHookFiresWhenContextIsInvalid(): void
     {
         // Invalid context — variation returns default, but hooks should still fire so

--- a/tests/Hooks/LDClientHooksTest.php
+++ b/tests/Hooks/LDClientHooksTest.php
@@ -145,12 +145,11 @@ class LDClientHooksTest extends TestCase
         $this->assertSame('v', $value);
     }
 
-    public function testAfterEvaluationFiresEvenWhenEvaluationThrowsThrowable(): void
+    public function testAfterEvaluationFiresWhenEvaluationThrowsNonExceptionThrowable(): void
     {
-        // evaluateInternal only catches \Exception, but spec 1.3.4 requires afterEvaluation
-        // to always run after beforeEvaluation. Simulate a non-Exception \Throwable
-        // propagating from the feature requester and assert afterEvaluation still fires
-        // with a detail whose reason indicates an exception.
+        // evaluateInternal catches \Throwable so a non-Exception error (e.g. TypeError)
+        // from a downstream component is converted into an EXCEPTION_ERROR detail rather
+        // than propagating. Hooks must still fire, and afterEvaluation must see that detail.
         $throwingRequester = new class extends MockFeatureRequester {
             public function getFeature(string $key): ?\LaunchDarkly\Impl\Model\FeatureFlag
             {
@@ -160,12 +159,8 @@ class LDClientHooksTest extends TestCase
         $hook = new RecordingHook('A');
         $client = $this->makeClient(['feature_requester' => $throwingRequester, 'hooks' => [$hook]]);
 
-        try {
-            $client->variation('flag', LDContext::create('u'), 'default');
-            $this->fail('expected TypeError to propagate');
-        } catch (\TypeError) {
-            // expected
-        }
+        $value = $client->variation('flag', LDContext::create('u'), 'default');
+        $this->assertSame('default', $value);
 
         $this->assertCount(2, $hook->calls);
         $this->assertSame('beforeEvaluation', $hook->calls[0]['stage']);

--- a/tests/Hooks/LDClientHooksTest.php
+++ b/tests/Hooks/LDClientHooksTest.php
@@ -55,7 +55,7 @@ class LDClientHooksTest extends TestCase
     public function testVariationInvokesBeforeAndAfterInOrder(): void
     {
         $this->addFlag('flag', 'v');
-        $shared = [];
+        $shared = new CallLog();
         $a = new RecordingHook('A', $shared);
         $b = new RecordingHook('B', $shared);
 
@@ -64,7 +64,7 @@ class LDClientHooksTest extends TestCase
 
         $this->assertSame(
             ['A:beforeEvaluation', 'B:beforeEvaluation', 'B:afterEvaluation', 'A:afterEvaluation'],
-            array_map(fn ($e) => $e['hook'] . ':' . $e['stage'], $shared),
+            array_map(fn ($e) => $e['hook'] . ':' . $e['stage'], $shared->calls),
         );
     }
 
@@ -243,7 +243,7 @@ class LDClientHooksTest extends TestCase
     public function testHookRegisteredViaAllMechanismsAllFire(): void
     {
         $this->addFlag('flag', 'v');
-        $shared = [];
+        $shared = new CallLog();
         $a = new RecordingHook('A', $shared);
         $b = new RecordingHook('B', $shared);
         $client = $this->makeClient(['hooks' => [$a]]);
@@ -252,7 +252,7 @@ class LDClientHooksTest extends TestCase
         $client->variation('flag', LDContext::create('u'), 'default');
         $this->assertSame(
             ['A:beforeEvaluation', 'B:beforeEvaluation', 'B:afterEvaluation', 'A:afterEvaluation'],
-            array_map(fn ($e) => $e['hook'] . ':' . $e['stage'], $shared),
+            array_map(fn ($e) => $e['hook'] . ':' . $e['stage'], $shared->calls),
         );
     }
 

--- a/tests/Hooks/LDClientHooksTest.php
+++ b/tests/Hooks/LDClientHooksTest.php
@@ -1,0 +1,283 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaunchDarkly\Tests\Hooks;
+
+use LaunchDarkly\EvaluationReason;
+use LaunchDarkly\Hooks\EvaluationSeriesContext;
+use LaunchDarkly\Hooks\Hook;
+use LaunchDarkly\Hooks\Metadata;
+use LaunchDarkly\Hooks\TrackSeriesContext;
+use LaunchDarkly\LDClient;
+use LaunchDarkly\LDContext;
+use LaunchDarkly\Migrations\Stage;
+use LaunchDarkly\Tests\MockEventProcessor;
+use LaunchDarkly\Tests\MockFeatureRequester;
+use LaunchDarkly\Tests\ModelBuilders;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class LDClientHooksTest extends TestCase
+{
+    private MockFeatureRequester $mockRequester;
+
+    public function setUp(): void
+    {
+        $this->mockRequester = new MockFeatureRequester();
+    }
+
+    /**
+     * @param array<string, mixed> $overrideOptions
+     */
+    private function makeClient(array $overrideOptions = []): LDClient
+    {
+        $options = [
+            'feature_requester' => $this->mockRequester,
+            'event_processor' => new MockEventProcessor(),
+            'logger' => new \Psr\Log\NullLogger(),
+        ];
+        return new LDClient('someKey', array_merge($options, $overrideOptions));
+    }
+
+    private function addFlag(string $key, mixed $value): void
+    {
+        $flag = ModelBuilders::flagBuilder($key)
+            ->version(1)
+            ->on(false)
+            ->variations($value)
+            ->offVariation(0)
+            ->fallthroughVariation(0)
+            ->build();
+        $this->mockRequester->addFlag($flag);
+    }
+
+    public function testVariationInvokesBeforeAndAfterInOrder(): void
+    {
+        $this->addFlag('flag', 'v');
+        $shared = [];
+        $a = new RecordingHook('A', $shared);
+        $b = new RecordingHook('B', $shared);
+
+        $client = $this->makeClient(['hooks' => [$a, $b]]);
+        $client->variation('flag', LDContext::create('u'), 'default');
+
+        $this->assertSame(
+            ['A:beforeEvaluation', 'B:beforeEvaluation', 'B:afterEvaluation', 'A:afterEvaluation'],
+            array_map(fn ($e) => $e['hook'] . ':' . $e['stage'], $shared),
+        );
+    }
+
+    public function testVariationPassesCorrectMethodAndContext(): void
+    {
+        $this->addFlag('flag', 'v');
+        $hook = new RecordingHook('A');
+        $client = $this->makeClient(['hooks' => [$hook]]);
+
+        $context = LDContext::create('u');
+        $client->variation('flag', $context, 'the-default');
+
+        /** @var EvaluationSeriesContext $seriesCtx */
+        $seriesCtx = $hook->calls[0]['ctx'];
+        $this->assertSame('flag', $seriesCtx->flagKey);
+        $this->assertSame('the-default', $seriesCtx->defaultValue);
+        $this->assertSame('variation', $seriesCtx->method);
+        $this->assertSame($context, $seriesCtx->context);
+    }
+
+    public function testVariationDetailUsesVariationDetailMethodName(): void
+    {
+        $this->addFlag('flag', 'v');
+        $hook = new RecordingHook('A');
+        $client = $this->makeClient(['hooks' => [$hook]]);
+
+        $client->variationDetail('flag', LDContext::create('u'), 'default');
+
+        /** @var EvaluationSeriesContext $seriesCtx */
+        $seriesCtx = $hook->calls[0]['ctx'];
+        $this->assertSame('variationDetail', $seriesCtx->method);
+    }
+
+    public function testMigrationVariationUsesMigrationVariationMethodName(): void
+    {
+        $flag = ModelBuilders::flagBuilder('migration')
+            ->version(1)
+            ->on(false)
+            ->variations('off')
+            ->offVariation(0)
+            ->fallthroughVariation(0)
+            ->build();
+        $this->mockRequester->addFlag($flag);
+
+        $hook = new RecordingHook('A');
+        $client = $this->makeClient(['hooks' => [$hook]]);
+
+        $client->migrationVariation('migration', LDContext::create('u'), Stage::OFF);
+
+        /** @var EvaluationSeriesContext $seriesCtx */
+        $seriesCtx = $hook->calls[0]['ctx'];
+        $this->assertSame('migrationVariation', $seriesCtx->method);
+    }
+
+    public function testAfterEvaluationReceivesEvaluationDetail(): void
+    {
+        $this->addFlag('flag', 'v');
+        $hook = new RecordingHook('A');
+        $client = $this->makeClient(['hooks' => [$hook]]);
+
+        $client->variation('flag', LDContext::create('u'), 'default');
+
+        $afterCall = $hook->calls[1];
+        $this->assertSame('afterEvaluation', $afterCall['stage']);
+        $this->assertSame('v', $afterCall['detail']->getValue());
+    }
+
+    public function testHookExceptionDoesNotBreakEvaluation(): void
+    {
+        $this->addFlag('flag', 'v');
+        $hook = new RecordingHook('A', throwFrom: [
+            'beforeEvaluation' => new RuntimeException('x'),
+            'afterEvaluation' => new RuntimeException('y'),
+        ]);
+        $client = $this->makeClient(['hooks' => [$hook]]);
+
+        $value = $client->variation('flag', LDContext::create('u'), 'default');
+        $this->assertSame('v', $value);
+    }
+
+    public function testHookFiresWhenContextIsInvalid(): void
+    {
+        // Invalid context — variation returns default, but hooks should still fire so
+        // telemetry can be emitted for failed evaluations.
+        $hook = new RecordingHook('A');
+        $client = $this->makeClient(['hooks' => [$hook]]);
+
+        $client->variation('flag', LDContext::create(''), 'default');
+
+        $this->assertCount(2, $hook->calls);
+        $this->assertSame('beforeEvaluation', $hook->calls[0]['stage']);
+        $this->assertSame('afterEvaluation', $hook->calls[1]['stage']);
+        $this->assertSame(
+            EvaluationReason::USER_NOT_SPECIFIED_ERROR,
+            $hook->calls[1]['detail']->getReason()->getErrorKind(),
+        );
+    }
+
+    public function testTrackInvokesAfterTrack(): void
+    {
+        $hook = new RecordingHook('A');
+        $client = $this->makeClient(['hooks' => [$hook]]);
+
+        $client->track('event', LDContext::create('u'), ['d' => 1], 2.5);
+
+        $this->assertCount(1, $hook->calls);
+        /** @var TrackSeriesContext $tctx */
+        $tctx = $hook->calls[0]['ctx'];
+        $this->assertSame('event', $tctx->key);
+        $this->assertSame(['d' => 1], $tctx->data);
+        $this->assertSame(2.5, $tctx->metricValue);
+    }
+
+    public function testTrackDoesNotInvokeAfterTrackOnInvalidContext(): void
+    {
+        $hook = new RecordingHook('A');
+        $client = $this->makeClient(['hooks' => [$hook]]);
+
+        $client->track('event', LDContext::create(''), null);
+
+        $this->assertCount(0, $hook->calls);
+    }
+
+    public function testTrackMigrationOperationDoesNotInvokeAfterTrack(): void
+    {
+        $flag = ModelBuilders::flagBuilder('migration')
+            ->version(1)
+            ->on(false)
+            ->variations('off')
+            ->offVariation(0)
+            ->fallthroughVariation(0)
+            ->build();
+        $this->mockRequester->addFlag($flag);
+
+        $hook = new RecordingHook('A');
+        $client = $this->makeClient(['hooks' => [$hook]]);
+
+        $result = $client->migrationVariation('migration', LDContext::create('u'), Stage::OFF);
+        $tracker = $result['tracker'];
+        // Populate the tracker enough that build() returns an event (not a string error).
+        $tracker->operation(\LaunchDarkly\Migrations\Operation::READ);
+        $tracker->invoked(\LaunchDarkly\Migrations\Origin::OLD);
+
+        // Clear hook calls from migrationVariation above.
+        $hook->calls = [];
+
+        $client->trackMigrationOperation($tracker);
+
+        // afterTrack must not fire for migration events (spec 1.6 — only custom events).
+        $this->assertCount(0, $hook->calls);
+    }
+
+    public function testAddHookAfterConstruction(): void
+    {
+        $this->addFlag('flag', 'v');
+        $client = $this->makeClient();
+
+        $hook = new RecordingHook('A');
+        $client->addHook($hook);
+
+        $client->variation('flag', LDContext::create('u'), 'default');
+        $this->assertCount(2, $hook->calls);
+    }
+
+    public function testNonHookEntriesInOptionAreIgnored(): void
+    {
+        $this->addFlag('flag', 'v');
+        $hook = new RecordingHook('A');
+        $client = $this->makeClient(['hooks' => [$hook, 'not-a-hook', new \stdClass()]]);
+
+        // Should not throw; invalid entries silently dropped (with a warning log).
+        $client->variation('flag', LDContext::create('u'), 'default');
+        $this->assertCount(2, $hook->calls);
+    }
+
+    public function testHookRegisteredViaAllMechanismsAllFire(): void
+    {
+        $this->addFlag('flag', 'v');
+        $shared = [];
+        $a = new RecordingHook('A', $shared);
+        $b = new RecordingHook('B', $shared);
+        $client = $this->makeClient(['hooks' => [$a]]);
+        $client->addHook($b);
+
+        $client->variation('flag', LDContext::create('u'), 'default');
+        $this->assertSame(
+            ['A:beforeEvaluation', 'B:beforeEvaluation', 'B:afterEvaluation', 'A:afterEvaluation'],
+            array_map(fn ($e) => $e['hook'] . ':' . $e['stage'], $shared),
+        );
+    }
+
+    public function testEmptyHooksDoesNotBreakEvaluation(): void
+    {
+        $this->addFlag('flag', 'v');
+        $client = $this->makeClient();
+
+        $value = $client->variation('flag', LDContext::create('u'), 'default');
+        $this->assertSame('v', $value);
+    }
+
+    public function testNoOpHookImplementationDoesNotInterfere(): void
+    {
+        $noOp = new class extends Hook {
+            public function getMetadata(): Metadata
+            {
+                return new Metadata('NoOp');
+            }
+        };
+
+        $this->addFlag('flag', 'v');
+        $client = $this->makeClient(['hooks' => [$noOp]]);
+
+        $value = $client->variation('flag', LDContext::create('u'), 'default');
+        $this->assertSame('v', $value);
+    }
+}

--- a/tests/Hooks/RecordingHook.php
+++ b/tests/Hooks/RecordingHook.php
@@ -20,8 +20,8 @@ class RecordingHook extends Hook
     public array $calls = [];
 
     /**
-     * @param array<int, array<string, mixed>>|null $sharedLog When provided, all hooks sharing this list append
-     *   to it in the order of invocation. Allows cross-hook ordering assertions.
+     * @param CallLog|null $sharedLog When provided, all hooks sharing the same CallLog append to it
+     *   in invocation order. Allows cross-hook ordering assertions.
      * @param array<string, \Throwable> $throwFrom Maps stage name ('beforeEvaluation'|'afterEvaluation'|'afterTrack')
      *   to the exception that should be thrown when that stage runs.
      * @param array<string, array<string, mixed>> $returnData Additional data to merge into the return value of
@@ -29,7 +29,7 @@ class RecordingHook extends Hook
      */
     public function __construct(
         private readonly string $name,
-        private ?array &$sharedLog = null,
+        private readonly ?CallLog $sharedLog = null,
         private readonly array $throwFrom = [],
         private readonly array $returnData = [],
     ) {
@@ -76,8 +76,6 @@ class RecordingHook extends Hook
     {
         $entry = ['hook' => $this->name, 'stage' => $stage] + $payload;
         $this->calls[] = $entry;
-        if ($this->sharedLog !== null) {
-            $this->sharedLog[] = $entry;
-        }
+        $this->sharedLog?->append($entry);
     }
 }

--- a/tests/Hooks/RecordingHook.php
+++ b/tests/Hooks/RecordingHook.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaunchDarkly\Tests\Hooks;
+
+use LaunchDarkly\EvaluationDetail;
+use LaunchDarkly\Hooks\EvaluationSeriesContext;
+use LaunchDarkly\Hooks\Hook;
+use LaunchDarkly\Hooks\Metadata;
+use LaunchDarkly\Hooks\TrackSeriesContext;
+
+/**
+ * Hook that records every stage invocation to a shared log list. Optionally throws
+ * from configured stages and/or returns configured series data.
+ */
+class RecordingHook extends Hook
+{
+    /** @var array<int, array<string, mixed>> */
+    public array $calls = [];
+
+    /**
+     * @param array<int, array<string, mixed>>|null $sharedLog When provided, all hooks sharing this list append
+     *   to it in the order of invocation. Allows cross-hook ordering assertions.
+     * @param array<string, \Throwable> $throwFrom Maps stage name ('beforeEvaluation'|'afterEvaluation'|'afterTrack')
+     *   to the exception that should be thrown when that stage runs.
+     * @param array<string, array<string, mixed>> $returnData Additional data to merge into the return value of
+     *   the given stage.
+     */
+    public function __construct(
+        private readonly string $name,
+        private ?array &$sharedLog = null,
+        private readonly array $throwFrom = [],
+        private readonly array $returnData = [],
+    ) {
+    }
+
+    public function getMetadata(): Metadata
+    {
+        return new Metadata($this->name);
+    }
+
+    public function beforeEvaluation(EvaluationSeriesContext $seriesContext, array $data): array
+    {
+        $this->record('beforeEvaluation', ['ctx' => $seriesContext, 'data' => $data]);
+        if (isset($this->throwFrom['beforeEvaluation'])) {
+            throw $this->throwFrom['beforeEvaluation'];
+        }
+        return array_merge($data, $this->returnData['beforeEvaluation'] ?? []);
+    }
+
+    public function afterEvaluation(
+        EvaluationSeriesContext $seriesContext,
+        array $data,
+        EvaluationDetail $detail,
+    ): array {
+        $this->record('afterEvaluation', ['ctx' => $seriesContext, 'data' => $data, 'detail' => $detail]);
+        if (isset($this->throwFrom['afterEvaluation'])) {
+            throw $this->throwFrom['afterEvaluation'];
+        }
+        return array_merge($data, $this->returnData['afterEvaluation'] ?? []);
+    }
+
+    public function afterTrack(TrackSeriesContext $seriesContext): void
+    {
+        $this->record('afterTrack', ['ctx' => $seriesContext]);
+        if (isset($this->throwFrom['afterTrack'])) {
+            throw $this->throwFrom['afterTrack'];
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function record(string $stage, array $payload): void
+    {
+        $entry = ['hook' => $this->name, 'stage' => $stage] + $payload;
+        $this->calls[] = $entry;
+        if ($this->sharedLog !== null) {
+            $this->sharedLog[] = $entry;
+        }
+    }
+}


### PR DESCRIPTION
Implements the Hooks specification (evaluation series + track series) to
give users and LaunchDarkly integration packages an extension point for
observing flag evaluations and track calls.

- Public API under `LaunchDarkly\Hooks`: `Hook` (abstract base class),
  `Metadata`, `EvaluationSeriesContext`, `TrackSeriesContext`.
- `LDClient` accepts a `hooks` option at construction and exposes
  `addHook()` for runtime registration.
- `beforeEvaluation` / `afterEvaluation` fire around every `variation`,
  `variationDetail`, and `migrationVariation` call, with `afterEvaluation`
  running in reverse registration order per spec 1.3.4.
- `afterTrack` fires after a custom event is enqueued. It does not fire
  for `trackMigrationOperation` (not a custom event) or for `track` calls
  rejected due to an invalid context.
- Hook exceptions are caught and logged at the error level; when a stage
  errors, subsequent stages receive the previous successful stage's data
  (spec 1.3.7.1).
- `environmentId` is intentionally omitted from the series contexts until
  the SDK can populate it reliably; the spec lists it as optional.
- Identify series (1.4) and configuration handlers (1.5) are skipped
  because they are client-side only.
- Contract test service declares `evaluation-hooks` and `track-hooks`
  capabilities and wires harness-provided hook configs through a new
  `PostingHook` implementation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds synchronous hook execution around flag evaluation and custom event tracking, which can affect evaluation latency/ordering and introduces new error-isolation/logging paths in core client flows. Risk is mitigated by no-op defaults, `hasHooks()` fast-path, and tests covering ordering and exception handling.
> 
> **Overview**
> Adds a new public hooks API (`LaunchDarkly\Hooks\Hook`, `Metadata`, `EvaluationSeriesContext`, `TrackSeriesContext`) and wires hook execution into `LDClient`.
> 
> `LDClient` now accepts a `hooks` constructor option and a runtime `addHook()` method; it runs `beforeEvaluation`/`afterEvaluation` around `variation`, `variationDetail`, and `migrationVariation` (with reverse order for `afterEvaluation`), and runs `afterTrack` after successful `track()` calls. Hook stage failures are caught/logged and isolated via the new internal `Impl\Hooks\HookRunner`, and evaluation error handling is widened to catch `\Throwable`.
> 
> Updates the contract test service to advertise `evaluation-hooks`/`track-hooks` and to instantiate harness-configured hooks via a new `PostingHook`, and adds unit tests for ordering, data propagation, and exception isolation. Also updates the Psalm baseline for the new code and version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c53211baed7e97f83c85f0716778f7fc54140835. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->