### PR TITLE
fix: Cast X-LaunchDarkly-Event-Schema header to string

### DIFF
--- a/src/LaunchDarkly/Impl/Util.php
+++ b/src/LaunchDarkly/Impl/Util.php
@@ -138,7 +138,7 @@ class Util
     public static function eventHeaders(string $sdkKey, array $options): array
     {
         $headers = Util::defaultHeaders($sdkKey, $options);
-        $headers['X-LaunchDarkly-Event-Schema'] = EventPublisher::CURRENT_SCHEMA_VERSION;
+        $headers['X-LaunchDarkly-Event-Schema'] = (string) EventPublisher::CURRENT_SCHEMA_VERSION;
         // Only the presence of this header is important. We encode a string
         // value of 'true' to ensure it isn't dropped along the way.
         $headers['X-LaunchDarkly-Unsummarized'] = 'true';

--- a/tests/Impl/UtilTest.php
+++ b/tests/Impl/UtilTest.php
@@ -26,4 +26,16 @@ class UtilTest extends TestCase
 
         $this->assertEquals(504, $counts);
     }
+
+    public function testEventHeaderValuesAreStrings(): void
+    {
+        // guzzlehttp/guzzle 7.11+ deprecates non-string header values and
+        // guzzle 8.0 will reject them, so every event header value must be a
+        // string. See https://github.com/launchdarkly/php-server-sdk/issues/246
+        $headers = Util::eventHeaders('sdk-key', []);
+
+        foreach ($headers as $name => $value) {
+            $this->assertIsString($value, "header '$name' should be a string");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

`Util::eventHeaders()` set the `X-LaunchDarkly-Event-Schema` header to `EventPublisher::CURRENT_SCHEMA_VERSION`, which is an int. Since guzzlehttp/guzzle 7.11 this emits a deprecation warning, and guzzle 8.0 will reject non-string header values outright. This casts the value to a string so event publishing continues to work without warnings.

Added a unit test asserting that every value returned by `eventHeaders()` is a string, which guards against any future header being added as a non-string.

Fixes #246

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-header type fix and a unit test; no behavior change beyond avoiding Guzzle deprecation/errors on event publishing.
> 
> **Overview**
> **`Util::eventHeaders()`** now sets **`X-LaunchDarkly-Event-Schema`** with an explicit **`(string)`** cast on **`EventPublisher::CURRENT_SCHEMA_VERSION`** (an int constant), so event HTTP clients get string header values as required by **guzzlehttp/guzzle 7.11+** and future **8.0**.
> 
> A new **`testEventHeaderValuesAreStrings`** test loops over all headers from **`eventHeaders()`** and asserts each value is a string, preventing regressions when new headers are added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f01d52fdaec34e81faa958abc3a6e793ff50a8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->