### PR TITLE
chore: Use Maven Central mirror and cache for WireMock in Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,19 @@ jobs:
       - name: Install java support
         run: choco install -y javaruntime
 
+      - name: Cache wiremock
+        id: cache-wiremock
+        uses: actions/cache@v4
+        with:
+          path: wiremock.jar
+          key: wiremock-jre8-standalone-2.31.0
+
       - name: Download wiremock
-        run: Invoke-WebRequest -Uri https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-jre8-standalone/2.31.0/wiremock-jre8-standalone-2.31.0.jar -UseBasicParsing -OutFile wiremock.jar
+        if: steps.cache-wiremock.outputs.cache-hit != 'true'
+        # Use the Google-hosted Maven Central mirror rather than repo1.maven.org.
+        # Maven Central blocks GitHub's shared runner IPs for automated consumption,
+        # while the GCS mirror serves the identical artifact without that limit.
+        run: Invoke-WebRequest -Uri https://maven-central.storage-download.googleapis.com/maven2/com/github/tomakehurst/wiremock-jre8-standalone/2.31.0/wiremock-jre8-standalone-2.31.0.jar -UseBasicParsing -OutFile wiremock.jar
 
       - name: Verify checksum
         shell: bash


### PR DESCRIPTION
## Summary

The Windows CI job downloaded the WireMock standalone jar directly from Maven Central (`repo1.maven.org`) on every run. Maven Central blocks GitHub's shared runner IPs for automated consumption, returning an HTTP 403 Terms of Service error and failing the build.

This change:

- Switches the download to the Google-hosted Maven Central mirror (`maven-central.storage-download.googleapis.com`), which serves the identical artifact and is not subject to the per-IP block.
- Caches the jar with `actions/cache` keyed on the WireMock version, so it is only fetched on a cache miss.

The existing checksum verification step is unchanged and now validates both freshly downloaded and cache-restored jars.

A code search across the `launchdarkly` and `launchdarkly-labs` orgs confirms `php-server-sdk` is the only repository downloading the WireMock standalone jar this way, so no other repos need the fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to artifact download and caching; runtime SDK behavior is unchanged.
> 
> **Overview**
> Fixes **Windows CI** failures when fetching the WireMock standalone JAR from `repo1.maven.org` (HTTP 403 from Maven Central’s automated-use limits on shared GitHub runner IPs).
> 
> The workflow now **caches** `wiremock.jar` with `actions/cache@v4` (keyed to WireMock **2.31.0**) and only runs the download step on a cache miss. The download URL moves to the **Google-hosted Maven Central mirror** (`maven-central.storage-download.googleapis.com`) for the same artifact. The existing **SHA-256 checksum** step still runs for both freshly downloaded and restored jars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 486b81a6ecadd4f6b6b3c220abf39c604e89ddae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->