### PR TITLE
fix: Redact anonymous context attributes in migration op and custom events

### DIFF
--- a/src/LaunchDarkly/Impl/Events/EventSerializer.php
+++ b/src/LaunchDarkly/Impl/Events/EventSerializer.php
@@ -48,10 +48,10 @@ class EventSerializer
 
     private function filterEvent(array $e): array
     {
-        // Feature and migration op events inline the full context, so anonymous context
-        // attributes must be redacted for both. Other event kinds do not redact anonymous
+        // Feature, custom, and migration op events inline the full context, so anonymous context
+        // attributes must be redacted for all of them. Other event kinds do not redact anonymous
         // attributes.
-        $redactAnonymousAttributes = in_array($e['kind'] ?? '', ['feature', 'migration_op'], true);
+        $redactAnonymousAttributes = in_array($e['kind'] ?? '', ['feature', 'custom', 'migration_op'], true);
 
         $ret = [];
         foreach ($e as $key => $value) {

--- a/src/LaunchDarkly/Impl/Events/EventSerializer.php
+++ b/src/LaunchDarkly/Impl/Events/EventSerializer.php
@@ -48,12 +48,15 @@ class EventSerializer
 
     private function filterEvent(array $e): array
     {
-        $isFeatureEvent = ($e['kind'] ?? '') == 'feature';
+        // Feature and migration op events inline the full context, so anonymous context
+        // attributes must be redacted for both. Other event kinds do not redact anonymous
+        // attributes.
+        $redactAnonymousAttributes = in_array($e['kind'] ?? '', ['feature', 'migration_op'], true);
 
         $ret = [];
         foreach ($e as $key => $value) {
             if ($key == 'context') {
-                $ret[$key] = $this->serializeContext($value, $isFeatureEvent);
+                $ret[$key] = $this->serializeContext($value, $redactAnonymousAttributes);
             } else {
                 $ret[$key] = $value;
             }

--- a/tests/Impl/Events/EventSerializerTest.php
+++ b/tests/Impl/Events/EventSerializerTest.php
@@ -133,6 +133,30 @@ class EventSerializerTest extends TestCase
         $this->assertEquals([$expected], json_decode($json, true));
     }
 
+    public function testRedactsAllAttributesFromAnonymousContextWithMigrationOpEvent()
+    {
+        $anonymousContext = LDContext::builder('abc')
+            ->anonymous(true)
+            ->set('bizzle', 'def')
+            ->set('dizzle', 'ghi')
+            ->set('firstName', 'Sue')
+            ->build();
+
+        $es = new EventSerializer([]);
+        $event = $this->makeEvent($anonymousContext);
+        $event['kind'] = 'migration_op';
+        $json = $es->serializeEvents([$event]);
+
+        // Migration op events inline the full context, so anonymous attributes must be redacted.
+        $expectedContextOutput = $this->getContextResultWithAllAttrsHidden();
+        $expectedContextOutput['anonymous'] = true;
+
+        $expected = $this->makeEvent($expectedContextOutput);
+        $expected['kind'] = 'migration_op';
+
+        $this->assertEquals([$expected], json_decode($json, true));
+    }
+
     public function testDoesNotRedactAttributesFromAnonymousContextWithNonFeatureEvent()
     {
         $anonymousContext = LDContext::builder('abc')

--- a/tests/Impl/Events/EventSerializerTest.php
+++ b/tests/Impl/Events/EventSerializerTest.php
@@ -157,6 +157,30 @@ class EventSerializerTest extends TestCase
         $this->assertEquals([$expected], json_decode($json, true));
     }
 
+    public function testRedactsAllAttributesFromAnonymousContextWithCustomEvent()
+    {
+        $anonymousContext = LDContext::builder('abc')
+            ->anonymous(true)
+            ->set('bizzle', 'def')
+            ->set('dizzle', 'ghi')
+            ->set('firstName', 'Sue')
+            ->build();
+
+        $es = new EventSerializer([]);
+        $event = $this->makeEvent($anonymousContext);
+        $event['kind'] = 'custom';
+        $json = $es->serializeEvents([$event]);
+
+        // Custom events inline the full context, so anonymous attributes must be redacted.
+        $expectedContextOutput = $this->getContextResultWithAllAttrsHidden();
+        $expectedContextOutput['anonymous'] = true;
+
+        $expected = $this->makeEvent($expectedContextOutput);
+        $expected['kind'] = 'custom';
+
+        $this->assertEquals([$expected], json_decode($json, true));
+    }
+
     public function testDoesNotRedactAttributesFromAnonymousContextWithNonFeatureEvent()
     {
         $anonymousContext = LDContext::builder('abc')


### PR DESCRIPTION
## Summary

The event serializer only requested anonymous-attribute redaction for `feature` events. Migration op events and custom events also inline the full context, so an anonymous context kept its attributes in `migration_op` and `custom` events while ordinary events redacted them and listed them under `_meta.redactedAttributes`.

This requests anonymous redaction for `migration_op` and `custom` events as well as `feature` events. Explicit private-attribute redaction already worked on every event kind; this closes the anonymous-redaction gap for both event types.

Adds EventSerializer regression tests for the migration op and custom event cases.

Found by running the expanded SDK contract-test-harness migration + custom-event suites against the PHP contract test service; verified both suites now pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fixes a privacy gap in outbound analytics payloads; behavior change is limited to custom and migration_op serialization and is covered by new tests.
> 
> **Overview**
> **Anonymous context redaction** now applies when serializing **`custom`** and **`migration_op`** events, not only **`feature`** events. Those kinds inline the full context, so they must use the same anonymous-attribute stripping (with `_meta.redactedAttributes`) as feature events; other kinds (e.g. identify) still leave anonymous attributes visible.
> 
> `EventSerializer::filterEvent` drives this via a shared `in_array` check on event kind instead of treating only `feature` as special. Regression tests cover anonymous contexts for both new kinds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d93b6e4cb2c64b714d2b09f4df139af52d67ec32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->