### PR TITLE
fix: Check the deleted marker before decoding items from a persistent store

### DIFF
--- a/src/LaunchDarkly/Impl/Integrations/FeatureRequesterBase.php
+++ b/src/LaunchDarkly/Impl/Integrations/FeatureRequesterBase.php
@@ -105,7 +105,7 @@ class FeatureRequesterBase implements FeatureRequester
             // Check the deleted marker before decoding. Some store writers
             // persist tombstones that omit most of the schema, and the model
             // decoder requires the full schema.
-            if ($json['deleted'] ?? false) {
+            if (($json['deleted'] ?? false) === true) {
                 $this->_logger->warning("FeatureRequester: Attempted to get deleted feature with key: " . $key);
                 return null;
             }
@@ -126,7 +126,7 @@ class FeatureRequesterBase implements FeatureRequester
     {
         $json = $this->getJsonItem(self::SEGMENTS_NAMESPACE, $key);
         if ($json) {
-            if ($json['deleted'] ?? false) {
+            if (($json['deleted'] ?? false) === true) {
                 $this->_logger->warning("FeatureRequester: Attempted to get deleted segment with key: " . $key);
                 return null;
             }
@@ -147,7 +147,7 @@ class FeatureRequesterBase implements FeatureRequester
         $jsonList = $this->getJsonItemList(self::FEATURES_NAMESPACE);
         $itemsOut = [];
         foreach ($jsonList as $json) {
-            if ($json['deleted'] ?? false) {
+            if (($json['deleted'] ?? false) === true) {
                 continue;
             }
             $flag = FeatureFlag::decode($json);

--- a/src/LaunchDarkly/Impl/Integrations/FeatureRequesterBase.php
+++ b/src/LaunchDarkly/Impl/Integrations/FeatureRequesterBase.php
@@ -102,12 +102,14 @@ class FeatureRequesterBase implements FeatureRequester
     {
         $json = $this->getJsonItem(self::FEATURES_NAMESPACE, $key);
         if ($json) {
-            $flag = FeatureFlag::decode($json);
-            if ($flag->isDeleted()) {
+            // Check the deleted marker before decoding. Some store writers
+            // persist tombstones that omit most of the schema, and the model
+            // decoder requires the full schema.
+            if ($json['deleted'] ?? false) {
                 $this->_logger->warning("FeatureRequester: Attempted to get deleted feature with key: " . $key);
                 return null;
             }
-            return $flag;
+            return FeatureFlag::decode($json);
         } else {
             $this->_logger->warning("FeatureRequester: Attempted to get missing feature with key: " . $key);
             return null;
@@ -124,12 +126,11 @@ class FeatureRequesterBase implements FeatureRequester
     {
         $json = $this->getJsonItem(self::SEGMENTS_NAMESPACE, $key);
         if ($json) {
-            $segment = Segment::decode($json);
-            if ($segment->isDeleted()) {
+            if ($json['deleted'] ?? false) {
                 $this->_logger->warning("FeatureRequester: Attempted to get deleted segment with key: " . $key);
                 return null;
             }
-            return $segment;
+            return Segment::decode($json);
         } else {
             $this->_logger->warning("FeatureRequester: Attempted to get missing segment with key: " . $key);
             return null;
@@ -146,10 +147,11 @@ class FeatureRequesterBase implements FeatureRequester
         $jsonList = $this->getJsonItemList(self::FEATURES_NAMESPACE);
         $itemsOut = [];
         foreach ($jsonList as $json) {
-            $flag = FeatureFlag::decode($json);
-            if (!$flag->isDeleted()) {
-                $itemsOut[$flag->getKey()] = $flag;
+            if ($json['deleted'] ?? false) {
+                continue;
             }
+            $flag = FeatureFlag::decode($json);
+            $itemsOut[$flag->getKey()] = $flag;
         }
         return $itemsOut;
     }

--- a/src/LaunchDarkly/Impl/Model/FeatureFlag.php
+++ b/src/LaunchDarkly/Impl/Model/FeatureFlag.php
@@ -144,6 +144,13 @@ class FeatureFlag
         return $this->_debugEventsUntilDate;
     }
 
+    /**
+     * The requester checks the deleted marker on the raw JSON before it
+     * decodes, so this accessor has no internal callers. It stays because the
+     * model mirrors the flag schema.
+     *
+     * @psalm-suppress PossiblyUnusedMethod
+     */
     public function isDeleted(): bool
     {
         return $this->_deleted;

--- a/src/LaunchDarkly/Impl/Model/FeatureFlag.php
+++ b/src/LaunchDarkly/Impl/Model/FeatureFlag.php
@@ -145,10 +145,6 @@ class FeatureFlag
     }
 
     /**
-     * The requester checks the deleted marker on the raw JSON before it
-     * decodes, so this accessor has no internal callers. It stays because the
-     * model mirrors the flag schema.
-     *
      * @psalm-suppress PossiblyUnusedMethod
      */
     public function isDeleted(): bool

--- a/src/LaunchDarkly/Impl/Model/Segment.php
+++ b/src/LaunchDarkly/Impl/Model/Segment.php
@@ -87,10 +87,6 @@ class Segment
     }
 
     /**
-     * The requester checks the deleted marker on the raw JSON before it
-     * decodes, so this accessor has no internal callers. It stays because the
-     * model mirrors the segment schema.
-     *
      * @psalm-suppress PossiblyUnusedMethod
      */
     public function isDeleted(): bool

--- a/src/LaunchDarkly/Impl/Model/Segment.php
+++ b/src/LaunchDarkly/Impl/Model/Segment.php
@@ -86,6 +86,13 @@ class Segment
         return static::getDecoder()($v);
     }
 
+    /**
+     * The requester checks the deleted marker on the raw JSON before it
+     * decodes, so this accessor has no internal callers. It stays because the
+     * model mirrors the segment schema.
+     *
+     * @psalm-suppress PossiblyUnusedMethod
+     */
     public function isDeleted(): bool
     {
         return $this->_deleted;

--- a/tests/Impl/Integrations/FeatureRequesterBaseTest.php
+++ b/tests/Impl/Integrations/FeatureRequesterBaseTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaunchDarkly\Tests\Impl\Integrations;
+
+use LaunchDarkly\Impl\Integrations\FeatureRequesterBase;
+use PHPUnit\Framework\TestCase;
+
+class FakeStoreFeatureRequester extends FeatureRequesterBase
+{
+    /** @var array<string, array<string, string>> */
+    private array $data;
+
+    /**
+     * @param array<string, array<string, string>> $data map of namespace to (key to raw JSON string)
+     */
+    public function __construct(array $data)
+    {
+        parent::__construct('', '', []);
+        $this->data = $data;
+    }
+
+    protected function readItemString(string $namespace, string $key): ?string
+    {
+        return $this->data[$namespace][$key] ?? null;
+    }
+
+    protected function readItemStringList(string $namespace): ?array
+    {
+        return array_values($this->data[$namespace] ?? []);
+    }
+}
+
+class FeatureRequesterBaseTest extends TestCase
+{
+    private const FLAG_JSON = '{"key":"flagkey","version":1,"on":true,"prerequisites":[],"salt":"salty",' .
+        '"targets":[],"contextTargets":[],"rules":[],"fallthrough":{"variation":0},"offVariation":1,' .
+        '"variations":["fall","off"],"deleted":false,"trackEvents":false,"trackEventsFallthrough":false,' .
+        '"debugEventsUntilDate":null,"clientSide":false}';
+
+    private const SEGMENT_JSON = '{"key":"segkey","version":1,"included":[],"excluded":[],"rules":[],' .
+        '"salt":"salty","deleted":false}';
+
+    private const FULL_FLAG_TOMBSTONE_JSON = '{"key":"deletedkey","version":2,"on":false,"prerequisites":[],' .
+        '"salt":"","targets":[],"contextTargets":[],"rules":[],"fallthrough":{},"offVariation":null,' .
+        '"variations":[],"deleted":true,"trackEvents":false,"trackEventsFallthrough":false,' .
+        '"debugEventsUntilDate":null,"clientSide":false}';
+
+    private const MINIMAL_TOMBSTONE_JSON = '{"version":2,"deleted":true}';
+
+    private const KEYED_MINIMAL_TOMBSTONE_JSON = '{"key":"deletedkey","version":2,"deleted":true}';
+
+    public function testGetFeatureReturnsFlag(): void
+    {
+        $requester = new FakeStoreFeatureRequester(['features' => ['flagkey' => self::FLAG_JSON]]);
+        $flag = $requester->getFeature('flagkey');
+        $this->assertNotNull($flag);
+        $this->assertEquals('flagkey', $flag->getKey());
+    }
+
+    public function testGetFeatureReturnsNullForFullSchemaTombstone(): void
+    {
+        $requester = new FakeStoreFeatureRequester(
+            ['features' => ['deletedkey' => self::FULL_FLAG_TOMBSTONE_JSON]]
+        );
+        $this->assertNull($requester->getFeature('deletedkey'));
+    }
+
+    public function testGetFeatureReturnsNullForMinimalTombstone(): void
+    {
+        $requester = new FakeStoreFeatureRequester(
+            ['features' => ['deletedkey' => self::MINIMAL_TOMBSTONE_JSON]]
+        );
+        $this->assertNull($requester->getFeature('deletedkey'));
+    }
+
+    public function testGetFeatureReturnsNullForKeyedMinimalTombstone(): void
+    {
+        $requester = new FakeStoreFeatureRequester(
+            ['features' => ['deletedkey' => self::KEYED_MINIMAL_TOMBSTONE_JSON]]
+        );
+        $this->assertNull($requester->getFeature('deletedkey'));
+    }
+
+    public function testGetSegmentReturnsSegment(): void
+    {
+        $requester = new FakeStoreFeatureRequester(['segments' => ['segkey' => self::SEGMENT_JSON]]);
+        $segment = $requester->getSegment('segkey');
+        $this->assertNotNull($segment);
+        $this->assertEquals('segkey', $segment->getKey());
+    }
+
+    public function testGetSegmentReturnsNullForMinimalTombstone(): void
+    {
+        $requester = new FakeStoreFeatureRequester(
+            ['segments' => ['segkey' => self::MINIMAL_TOMBSTONE_JSON]]
+        );
+        $this->assertNull($requester->getSegment('segkey'));
+    }
+
+    public function testGetAllFeaturesSkipsTombstones(): void
+    {
+        $requester = new FakeStoreFeatureRequester(['features' => [
+            'flagkey' => self::FLAG_JSON,
+            'deleted1' => self::FULL_FLAG_TOMBSTONE_JSON,
+            'deleted2' => self::MINIMAL_TOMBSTONE_JSON,
+            'deleted3' => self::KEYED_MINIMAL_TOMBSTONE_JSON,
+        ]]);
+        $flags = $requester->getAllFeatures();
+        $this->assertNotNull($flags);
+        $this->assertEquals(['flagkey'], array_keys($flags));
+    }
+}


### PR DESCRIPTION
## Summary

`FeatureRequesterBase` decoded store items into the `FeatureFlag`/`Segment` model before checking whether the item was a deleted-item tombstone. The model decoder reads `key`, `on`, `salt`, `fallthrough`, and other properties from the raw array with no defaults, under `strict_types=1`. A tombstone that does not carry the full schema therefore threw a `TypeError` during decode. `TypeError` is an `\Error`, so it escaped the `catch (\Exception)` guard in `LDClient` and surfaced as an uncaught fatal in the application.

Minimal tombstones are a realistic input: several other server SDKs write `{"version":N,"deleted":true}` (with no key, and none of the other properties) to shared persistent stores when a flag or segment is deleted. With such a tombstone in the store:

- `allFlagsState()` fataled if the tombstone existed anywhere in the environment, even when the application never referenced the deleted flag.
- `variation()`/`variationDetail()` fataled when evaluating the deleted flag's key.

This change checks the `deleted` marker on the raw JSON array in `getFeature`, `getSegment`, and `getAllFeatures` before invoking the model decoder. Tombstones of any shape now behave as they should: the flag reads as not found and `allFlagsState()` skips it. Behavior for full-schema tombstones is unchanged, including the warning log on access.

Verified against a real Redis store via the predis integration: with `{"version":9,"deleted":true}` stored alongside live flags, `allFlagsState()` and evaluation of the deleted key both fataled before this change and now succeed, with the deleted key evaluating to the default value with a `FLAG_NOT_FOUND` reason.

SDK-2943

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Stops decoding store items into `FeatureFlag`/`Segment` before noticing they are tombstones. Incomplete `{"version":N,"deleted":true}` records from other SDKs previously caused a `TypeError` (uncaught by `LDClient`) on `variation()` and `allFlagsState()`.
> 
> `getFeature`, `getSegment`, and `getAllFeatures` now inspect `deleted` on the raw JSON and treat those items as not found (with the existing warning on single-item access). Full-schema tombstones behave the same. Tests cover live items plus full and minimal tombstones.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca6a9bdcc4428a2f4c7a7a3131f4f31c57ca92ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->