### PR TITLE
feat: Add payload_temp_dir option to send large event payloads via a file

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -208,9 +208,6 @@
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[!$baseUri]]></code>
     </RiskyTruthyFalsyComparison>
-    <UnusedReturnValue>
-      <code><![CDATA[bool]]></code>
-    </UnusedReturnValue>
   </file>
   <file src="src/LaunchDarkly/Impl/Integrations/FeatureRequesterBase.php">
     <ClassMustBeFinal>

--- a/src/LaunchDarkly/Impl/Integrations/CurlEventPublisher.php
+++ b/src/LaunchDarkly/Impl/Integrations/CurlEventPublisher.php
@@ -25,6 +25,11 @@ class CurlEventPublisher implements EventPublisher
     private int $_timeout;
     private bool $_isWindows;
 
+    /**
+     * The directory named by the payload_temp_dir option, or null if the option is not set.
+     */
+    private ?string $_payloadTempDir;
+
     /** @var array<string, string> */
     private array $_eventHeaders;
 
@@ -54,31 +59,78 @@ class CurlEventPublisher implements EventPublisher
         $this->_connectTimeout = intval($options['connect_timeout']);
         $this->_timeout = intval($options['timeout']);
         $this->_isWindows = PHP_OS_FAMILY == 'Windows';
+        $this->_payloadTempDir = $this->resolvePayloadTempDir($options['payload_temp_dir'] ?? null);
+    }
+
+    /**
+     * Reads the payload_temp_dir option.
+     *
+     * The value true means the system temporary directory. A non-empty string is a directory path.
+     * Any other value means the option is not set.
+     */
+    private function resolvePayloadTempDir(mixed $option): ?string
+    {
+        if ($option === true) {
+            return sys_get_temp_dir();
+        }
+
+        return (is_string($option) && $option !== '') ? $option : null;
     }
 
     public function publish(string $payload): bool
     {
-        $tmpfile = tempnam(sys_get_temp_dir(), 'ld-');
-        if ($tmpfile === false) {
-            return false;
-        }
-        if (file_put_contents($tmpfile, $payload) === false) {
-            unlink($tmpfile);
-            return false;
-        }
-
+        // Windows always sends the payload from a file.
         if ($this->_isWindows) {
-            $args = $this->createPowershellArgs($tmpfile);
-            $this->makePowershellRequest($args);
-        } else {
-            $args = $this->createCurlArgs($tmpfile) . " ; rm -f " . escapeshellarg($tmpfile);
-            $this->makeCurlRequest($args);
+            $payloadFile = $this->writePayloadFile($payload);
+            if ($payloadFile === null) {
+                return false;
+            }
+
+            return $this->makePowershellRequest($this->createPowershellArgs($payloadFile));
         }
 
-        return true;
+        if ($this->_payloadTempDir === null) {
+            return $this->makeCurlRequest($this->createCurlArgs("-d " . escapeshellarg($payload)));
+        }
+
+        $payloadFile = $this->writePayloadFile($payload);
+        if ($payloadFile === null) {
+            return false;
+        }
+
+        return $this->makeCurlRequest(
+            $this->createCurlArgs("--data-binary @" . escapeshellarg($payloadFile)),
+            $payloadFile
+        );
     }
 
-    private function createCurlArgs(string $payloadFile): string
+    /**
+     * Writes the payload to a new file.
+     *
+     * The file goes in the directory named by the payload_temp_dir option. The default is the
+     * system temporary directory.
+     *
+     * @return ?string the path of the file, or null if the whole payload could not be written
+     */
+    private function writePayloadFile(string $payload): ?string
+    {
+        $payloadFile = tempnam($this->_payloadTempDir ?? sys_get_temp_dir(), 'ld-');
+        if ($payloadFile === false) {
+            return null;
+        }
+
+        if (file_put_contents($payloadFile, $payload) !== strlen($payload)) {
+            unlink($payloadFile);
+            return null;
+        }
+
+        return $payloadFile;
+    }
+
+    /**
+     * Builds the curl command line. The caller supplies the option that provides the payload.
+     */
+    private function createCurlArgs(string $payloadOption): string
     {
         $scheme = $this->_ssl ? "https://" : "http://";
         $args = " -X POST";
@@ -89,18 +141,23 @@ class CurlEventPublisher implements EventPublisher
             $args.= " -H " . escapeshellarg("$key: $value");
         }
 
-        $args .= " --data-binary @" . escapeshellarg($payloadFile);
-        $args .= " " . escapeshellarg($scheme . $this->_host . ":" . $this->_port . $this->_path . "/bulk");
+        $args.= " " . $payloadOption;
+        $args.= " " . escapeshellarg($scheme . $this->_host . ":" . $this->_port . $this->_path . "/bulk");
         return $args;
     }
 
     /**
      * @psalm-suppress ForbiddenCode
      */
-    private function makeCurlRequest(string $args): bool
+    private function makeCurlRequest(string $args, ?string $payloadFile = null): bool
     {
-        $cmd = "( " . $this->_curl . " " . $args . " ) >> /dev/null 2>&1 &";
-        shell_exec($cmd);
+        $cmd = $this->_curl . " " . $args;
+        if ($payloadFile !== null) {
+            // The subshell keeps the removal grouped with the request that reads the file.
+            $cmd = "( " . $cmd . " ; rm -f " . escapeshellarg($payloadFile) . " )";
+        }
+
+        shell_exec($cmd . " >> /dev/null 2>&1 &");
         return true;
     }
 

--- a/src/LaunchDarkly/Impl/Integrations/CurlEventPublisher.php
+++ b/src/LaunchDarkly/Impl/Integrations/CurlEventPublisher.php
@@ -58,27 +58,27 @@ class CurlEventPublisher implements EventPublisher
 
     public function publish(string $payload): bool
     {
-        if (!$this->_isWindows) {
-            $args = $this->createCurlArgs($payload);
-            return $this->makeCurlRequest($args);
-        }
-
         $tmpfile = tempnam(sys_get_temp_dir(), 'ld-');
         if ($tmpfile === false) {
             return false;
         }
-
         if (file_put_contents($tmpfile, $payload) === false) {
+            unlink($tmpfile);
             return false;
-        };
+        }
 
-        $args = $this->createPowershellArgs($tmpfile);
-        $this->makePowershellRequest($args);
+        if ($this->_isWindows) {
+            $args = $this->createPowershellArgs($tmpfile);
+            $this->makePowershellRequest($args);
+        } else {
+            $args = $this->createCurlArgs($tmpfile) . " ; rm -f " . escapeshellarg($tmpfile);
+            $this->makeCurlRequest($args);
+        }
 
         return true;
     }
 
-    private function createCurlArgs(string $payload): string
+    private function createCurlArgs(string $payloadFile): string
     {
         $scheme = $this->_ssl ? "https://" : "http://";
         $args = " -X POST";
@@ -89,8 +89,8 @@ class CurlEventPublisher implements EventPublisher
             $args.= " -H " . escapeshellarg("$key: $value");
         }
 
-        $args.= " -d " . escapeshellarg($payload);
-        $args.= " " . escapeshellarg($scheme . $this->_host . ":" . $this->_port . $this->_path . "/bulk");
+        $args .= " --data-binary @" . escapeshellarg($payloadFile);
+        $args .= " " . escapeshellarg($scheme . $this->_host . ":" . $this->_port . $this->_path . "/bulk");
         return $args;
     }
 
@@ -99,7 +99,7 @@ class CurlEventPublisher implements EventPublisher
      */
     private function makeCurlRequest(string $args): bool
     {
-        $cmd = $this->_curl . " " . $args . ">> /dev/null 2>&1 &";
+        $cmd = "( " . $this->_curl . " " . $args . " ) >> /dev/null 2>&1 &";
         shell_exec($cmd);
         return true;
     }

--- a/src/LaunchDarkly/Impl/Integrations/CurlEventPublisher.php
+++ b/src/LaunchDarkly/Impl/Integrations/CurlEventPublisher.php
@@ -86,7 +86,7 @@ class CurlEventPublisher implements EventPublisher
                 return false;
             }
 
-            return $this->makePowershellRequest($this->createPowershellArgs($payloadFile));
+            return $this->makePowershellRequest($payloadFile);
         }
 
         if ($this->_payloadTempDir === null) {
@@ -161,7 +161,14 @@ class CurlEventPublisher implements EventPublisher
         return true;
     }
 
-    private function createPowershellArgs(string $payloadFile): string
+    /**
+     * Sends the payload with PowerShell, in the background.
+     *
+     * PowerShell reads the payload from the named file. The file is removed when the request ends.
+     *
+     * @psalm-suppress ForbiddenCode
+     */
+    private function makePowershellRequest(string $payloadFile): bool
     {
         $headerString = "";
         foreach ($this->_eventHeaders as $key => $value) {
@@ -179,14 +186,6 @@ class CurlEventPublisher implements EventPublisher
         $args.= " -Uri " . escapeshellarg($scheme . $this->_host . ":" . $this->_port . $this->_path . "/bulk");
         $args.= " ; Remove-Item '$payloadFile'";
 
-        return $args;
-    }
-
-    /**
-     * @psalm-suppress ForbiddenCode
-     */
-    private function makePowershellRequest(string $args): bool
-    {
         $cmd = base64_encode(iconv('ISO-8859-1', 'UTF-16LE', $args));
         shell_exec("start /B powershell.exe -encodedCommand $cmd > nul 2>&1");
 

--- a/src/LaunchDarkly/Impl/Integrations/CurlEventPublisher.php
+++ b/src/LaunchDarkly/Impl/Integrations/CurlEventPublisher.php
@@ -90,7 +90,7 @@ class CurlEventPublisher implements EventPublisher
         }
 
         if ($this->_payloadTempDir === null) {
-            return $this->makeCurlRequest($this->createCurlArgs("-d " . escapeshellarg($payload)));
+            return $this->makeCurlRequest($payload);
         }
 
         $payloadFile = $this->writePayloadFile($payload);
@@ -98,10 +98,7 @@ class CurlEventPublisher implements EventPublisher
             return false;
         }
 
-        return $this->makeCurlRequest(
-            $this->createCurlArgs("--data-binary @" . escapeshellarg($payloadFile)),
-            $payloadFile
-        );
+        return $this->makeCurlRequest($payload, $payloadFile);
     }
 
     /**
@@ -128,9 +125,14 @@ class CurlEventPublisher implements EventPublisher
     }
 
     /**
-     * Builds the curl command line. The caller supplies the option that provides the payload.
+     * Sends the payload with curl, in the background.
+     *
+     * Curl reads the payload from the command line. Name a file that already holds the payload to
+     * have curl read the file instead. The file is removed when the request ends.
+     *
+     * @psalm-suppress ForbiddenCode
      */
-    private function createCurlArgs(string $payloadOption): string
+    private function makeCurlRequest(string $payload, ?string $payloadFile = null): bool
     {
         $scheme = $this->_ssl ? "https://" : "http://";
         $args = " -X POST";
@@ -141,17 +143,15 @@ class CurlEventPublisher implements EventPublisher
             $args.= " -H " . escapeshellarg("$key: $value");
         }
 
-        $args.= " " . $payloadOption;
-        $args.= " " . escapeshellarg($scheme . $this->_host . ":" . $this->_port . $this->_path . "/bulk");
-        return $args;
-    }
+        if ($payloadFile === null) {
+            $args.= " -d " . escapeshellarg($payload);
+        } else {
+            $args.= " --data-binary @" . escapeshellarg($payloadFile);
+        }
 
-    /**
-     * @psalm-suppress ForbiddenCode
-     */
-    private function makeCurlRequest(string $args, ?string $payloadFile = null): bool
-    {
-        $cmd = $this->_curl . " " . $args;
+        $args.= " " . escapeshellarg($scheme . $this->_host . ":" . $this->_port . $this->_path . "/bulk");
+
+        $cmd = $this->_curl . $args;
         if ($payloadFile !== null) {
             // The subshell keeps the removal grouped with the request that reads the file.
             $cmd = "( " . $cmd . " ; rm -f " . escapeshellarg($payloadFile) . " )";

--- a/src/LaunchDarkly/Integrations/Curl.php
+++ b/src/LaunchDarkly/Integrations/Curl.php
@@ -27,6 +27,13 @@ class Curl
      *
      * @param array $options  Configuration settings (can also be passed in the main client configuration):
      *   - `curl`: command for executing `curl`; defaults to `/usr/bin/env curl`
+     *   - `payload_temp_dir`: directory for the temporary file that holds the event payload. Use `true`
+     * for the system temporary directory, or a path to name a directory. On Unix the default is to pass
+     * the payload on the `curl` command line instead of writing a file. Set this option if a payload can
+     * be larger than the maximum argument length of the platform, which makes `escapeshellarg()` fail
+     * with `Argument exceeds the allowed length of N bytes`. On Windows the payload always goes into a
+     * file, and this option only names the directory; the default there is the system temporary
+     * directory.
      * @return mixed  an object to be stored in the `event_publisher` configuration property
      */
     public static function eventPublisher(array $options = []): mixed

--- a/tests/Impl/Integrations/CurlEventPublisherTest.php
+++ b/tests/Impl/Integrations/CurlEventPublisherTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace LaunchDarkly\Tests\Impl\Integrations;
+
+use LaunchDarkly\Impl\Integrations\CurlEventPublisher;
+use PHPUnit\Framework\TestCase;
+
+class CurlEventPublisherTest extends TestCase
+{
+    private const PAYLOAD = '{"kind":"bulk","events":[{"kind":"identify","key":"user with spaces"}]}';
+
+    private string $_workDir;
+
+    public function setUp(): void
+    {
+        if (PHP_OS_FAMILY === 'Windows') {
+            $this->markTestSkipped("These tests use a shell script to stand in for curl");
+        }
+
+        $this->_workDir = sys_get_temp_dir() . '/ld-curl-test-' . uniqid();
+        mkdir($this->_workDir . '/record', 0700, true);
+        mkdir($this->_workDir . '/payloads', 0700, true);
+
+        // This script records the arguments it receives, and a copy of any file that curl would
+        // read the payload from. The publisher runs the request in the background, so the tests
+        // wait for the arguments file to appear.
+        $script = "#!/bin/sh\n"
+            . "DEST=" . escapeshellarg($this->_workDir . '/record') . "\n"
+            . "for a in \"\$@\"; do\n"
+            . "  case \"\$a\" in\n"
+            . "    @*) cp \"\${a#@}\" \"\$DEST/payload\" ;;\n"
+            . "  esac\n"
+            . "done\n"
+            . "for a in \"\$@\"; do printf '%s\\n' \"\$a\"; done > \"\$DEST/args.tmp\"\n"
+            . "mv \"\$DEST/args.tmp\" \"\$DEST/args\"\n";
+
+        file_put_contents($this->_workDir . '/curl', $script);
+        chmod($this->_workDir . '/curl', 0700);
+    }
+
+    public function tearDown(): void
+    {
+        if (!isset($this->_workDir)) {
+            return;
+        }
+
+        foreach (glob($this->_workDir . '/{,*/}*', GLOB_BRACE) ?: [] as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+        foreach ([$this->_workDir . '/record', $this->_workDir . '/payloads', $this->_workDir] as $dir) {
+            @rmdir($dir);
+        }
+    }
+
+    private function makePublisher(array $options = []): CurlEventPublisher
+    {
+        return new CurlEventPublisher('sdk-key', array_merge([
+            'events_uri' => 'http://localhost:8080',
+            'timeout' => 3,
+            'connect_timeout' => 3,
+            'curl' => $this->_workDir . '/curl',
+        ], $options));
+    }
+
+    /**
+     * @return string[] the arguments that the stand-in for curl received
+     */
+    private function awaitRecordedArgs(): array
+    {
+        $path = $this->_workDir . '/record/args';
+
+        $deadline = microtime(true) + 3;
+        while (microtime(true) < $deadline) {
+            // PHP caches the result of a failed stat, so the loop must discard it to see the file.
+            clearstatcache(true, $path);
+            if (file_exists($path)) {
+                return explode("\n", rtrim(file_get_contents($path), "\n"));
+            }
+            usleep(1000);
+        }
+
+        $this->fail("The request did not run within the timeout");
+    }
+
+    /**
+     * @return ?string the argument that names the file holding the payload
+     */
+    private function payloadFileArg(array $args): ?string
+    {
+        foreach ($args as $arg) {
+            if (str_starts_with($arg, '@')) {
+                return substr($arg, 1);
+            }
+        }
+
+        return null;
+    }
+
+    public function testPassesPayloadOnCommandLineByDefault()
+    {
+        $before = glob(sys_get_temp_dir() . '/ld-*') ?: [];
+
+        $this->assertTrue($this->makePublisher()->publish(self::PAYLOAD));
+
+        $args = $this->awaitRecordedArgs();
+        $this->assertContains('-d', $args);
+        $this->assertContains(self::PAYLOAD, $args);
+        $this->assertNotContains('--data-binary', $args);
+        $this->assertNull($this->payloadFileArg($args));
+
+        // Without the option, the publisher must not touch the filesystem at all.
+        $this->assertEquals($before, glob(sys_get_temp_dir() . '/ld-*') ?: []);
+    }
+
+    public function testWritesPayloadToNamedDirectory()
+    {
+        $publisher = $this->makePublisher(['payload_temp_dir' => $this->_workDir . '/payloads']);
+        $this->assertTrue($publisher->publish(self::PAYLOAD));
+
+        $args = $this->awaitRecordedArgs();
+        $this->assertContains('--data-binary', $args);
+        $this->assertNotContains('-d', $args);
+
+        $payloadFile = $this->payloadFileArg($args);
+        $this->assertNotNull($payloadFile);
+        $this->assertEquals($this->_workDir . '/payloads', dirname($payloadFile));
+        $this->assertEquals(self::PAYLOAD, file_get_contents($this->_workDir . '/record/payload'));
+    }
+
+    public function testUsesSystemTempDirectoryWhenOptionIsTrue()
+    {
+        $this->assertTrue($this->makePublisher(['payload_temp_dir' => true])->publish(self::PAYLOAD));
+
+        $payloadFile = $this->payloadFileArg($this->awaitRecordedArgs());
+        $this->assertNotNull($payloadFile);
+        $this->assertEquals(realpath(sys_get_temp_dir()), realpath(dirname($payloadFile)));
+        $this->assertEquals(self::PAYLOAD, file_get_contents($this->_workDir . '/record/payload'));
+    }
+
+    public function testRemovesPayloadFileAfterTheRequest()
+    {
+        $dir = $this->_workDir . '/payloads';
+        $this->assertTrue($this->makePublisher(['payload_temp_dir' => $dir])->publish(self::PAYLOAD));
+
+        $this->awaitRecordedArgs();
+
+        // The removal is chained after the request, so it can lag behind the recorded arguments.
+        $deadline = microtime(true) + 3;
+        while (microtime(true) < $deadline && (glob($dir . '/ld-*') ?: [])) {
+            usleep(1000);
+        }
+
+        $this->assertEmpty(glob($dir . '/ld-*') ?: []);
+    }
+}

--- a/tests/Impl/Integrations/CurlEventPublisherTest.php
+++ b/tests/Impl/Integrations/CurlEventPublisherTest.php
@@ -17,9 +17,14 @@ class CurlEventPublisherTest extends TestCase
             $this->markTestSkipped("These tests use a shell script to stand in for curl");
         }
 
-        $this->_workDir = sys_get_temp_dir() . '/ld-curl-test-' . uniqid();
-        mkdir($this->_workDir . '/record', 0700, true);
-        mkdir($this->_workDir . '/payloads', 0700, true);
+        $workDir = sys_get_temp_dir() . '/ld-curl-test-' . uniqid();
+        mkdir($workDir . '/record', 0700, true);
+        mkdir($workDir . '/payloads', 0700, true);
+
+        // tempnam() resolves the directory it is given, and the temporary directory on macOS is
+        // reached through a symbolic link. Resolve the path here so that the tests compare it to
+        // the path that the publisher reports.
+        $this->_workDir = realpath($workDir);
 
         // This script records the arguments it receives, and a copy of any file that curl would
         // read the payload from. The publisher runs the request in the background, so the tests

--- a/tests/Impl/Integrations/EventPublisherTest.php
+++ b/tests/Impl/Integrations/EventPublisherTest.php
@@ -38,10 +38,15 @@ class EventPublisherTest extends TestCase
         ];
 
         $curlPublisher = new Integrations\CurlEventPublisher('sdk-key', $config);
+        $curlFilePublisher = new Integrations\CurlEventPublisher(
+            'sdk-key',
+            array_merge($config, ['payload_temp_dir' => true])
+        );
         $guzzlePublisher = new Integrations\GuzzleEventPublisher('sdk-key', $config);
 
         return [
             [$curlPublisher],
+            [$curlFilePublisher],
             [$guzzlePublisher],
         ];
     }


### PR DESCRIPTION
PHP's `escapeshellarg()` rejects any input longer than `sysconf(_SC_ARG_MAX)`:
 it throws `ValueError: Argument exceeds the allowed length of N bytes`. On Alpine containers
`_SC_ARG_MAX` is 131072 bytes, so any flush whose payload exceeds ~128 KB crashes
the request that triggered the flush, and the events are lost.

The Windows path in the same class already avoids this problem by writing the
payload to a temp file.

## Environment

- SDK: 6.8.0; still present in v6.8.3 (latest)
- PHP: 8.5 (any ≥ 8.4 → `ValueError`; < 8.4 → fatal `E_ERROR`)
- OS: Alpine Linux containers (`getconf ARG_MAX` → 131072)

## Stack trace

```
ValueError: Argument exceeds the allowed length of 131072 bytes
    at .../vendor/launchdarkly/server-sdk/src/LaunchDarkly/Impl/Integrations/CurlEventPublisher.php:92
```

## Reproduction

```
$payload = json_encode(['kind' => 'bulk', 'events' => array_fill(0, 4000, [
            'kind' => 'identify',
            'context' => ['key' => 'user-1', 'name' => str_repeat('x', 500)],
        ])]);
// ~2.2 MB — above ARG_MAX on macOS (~1 MB), Alpine (128 KB) and Ubuntu (~2 MB)

        (new \LaunchDarkly\Impl\Integrations\CurlEventPublisher('fake-sdk-key', ['connect_timeout' => 3, 'timeout' => 3]))

// On a host where `getconf ARG_MAX` is 131072:
// PHP >= 8.4: ValueError: Argument exceeds the allowed length of 131072 bytes
// PHP < 8.4:  Fatal error: escapeshellarg(): Argument exceeds the allowed length of 131072 bytes
```




**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Fixes event flushes that crash on Unix when bulk payloads exceed `ARG_MAX` and `escapeshellarg()` throws **ValueError** (notably ~128 KB on Alpine).
> 
> **`CurlEventPublisher`** gains an optional **`payload_temp_dir`** setting (`true` → system temp, or a directory path). On Unix, behavior is unchanged unless the option is set; then the payload is written to a temp file, sent with **`curl --data-binary @file`**, and removed in a subshell after the background request. Windows still always uses a file; it now shares **`writePayloadFile()`** and a simplified PowerShell path instead of duplicating temp-file logic in **`publish()`**.
> 
> Public docs on **`Integrations\Curl::eventPublisher()`** describe when to enable the option. New **`CurlEventPublisherTest`** covers default inline `-d`, named temp dir, `payload_temp_dir => true`, and cleanup; the shared event publisher tests also exercise the file-based curl publisher.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9836c4c935244fc277135b6301a259eb916220c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->